### PR TITLE
feat(worker): print bad header in case of CRC error

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ["7.4", "8.0", "8.1"]
-        go: ["1.17.2"]
+        go: ["1.17.3"]
         os: ["ubuntu-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 👀 New:
 
 - ✏️ New internal message bus. Available globally. Supports wildcard subscriptions (for example: `http.*` will subscribe you to the all events coming from the `http` plugin). The subscriptions can be made from any RR plugin to any RR plugin.
+- ✏️ Now, RR will show in the returned error the bad header content in case of CRC mismatch error. More info in the [PR](https://github.com/spiral/roadrunner/pull/863).
 
 ## 🩹 Fixes:
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/shirou/gopsutil v3.21.10+incompatible
 	// spiral
 	github.com/spiral/errors v1.0.12
-	github.com/spiral/goridge/v3 v3.2.3
+	github.com/spiral/goridge/v3 v3.2.4
 	github.com/spiral/tcplisten v1.0.0
 	// spiral
 	github.com/stretchr/testify v1.7.0
@@ -27,7 +27,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 // indirect
+	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/shirou/gopsutil v3.21.10+incompatible h1:AL2kpVykjkqeN+MFe1WcwSBVUjGj
 github.com/shirou/gopsutil v3.21.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/spiral/errors v1.0.12 h1:38Waf8ZL/Xvxg4HTYGmrUbvi7TCHivmuatNQZlBhQ8s=
 github.com/spiral/errors v1.0.12/go.mod h1:j5UReqxZxfkwXkI9mFY87VhEXcXmSg7kAk5Sswy1eEA=
-github.com/spiral/goridge/v3 v3.2.3 h1:iNz6aD/c00hC50wo+qT8uP5ZZ3VdCAERXUtNiyDE3Yo=
-github.com/spiral/goridge/v3 v3.2.3/go.mod h1:DA4Ekw9qVcTvVouUNJgxESXURBHZ2SfkliCEIpEl9lA=
+github.com/spiral/goridge/v3 v3.2.4 h1:Octzn0kgpQY10vQhrf0a5RlzCVW1lIEuR6/IGYp0BW4=
+github.com/spiral/goridge/v3 v3.2.4/go.mod h1:a6qAtZy+FBaPj/76GweHj6SkgIr+oRVgW5p4e5vLZF4=
 github.com/spiral/tcplisten v1.0.0 h1:dII3R20Xslll6Uk60ac1JCn9zQwfwbt88CLrs3OryZg=
 github.com/spiral/tcplisten v1.0.0/go.mod h1:+anIsZh2ZYw2EogG2pO1yEZKcGN7lEf41hUQilctYJo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -42,7 +42,7 @@ github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2biQ=
 github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=
-github.com/vmihailenco/msgpack/v5 v5.3.4/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
@@ -53,8 +53,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cO
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 h1:kwrAHlwJ0DUBZwQ238v+Uod/3eZ8B2K5rYsUHBQvzmI=
-golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
+golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -89,9 +89,6 @@ func Pid(rl relay.Relay) (int64, error) {
 		return 0, err
 	}
 
-	if !fr.VerifyCRC(fr.Header()) {
-		return 0, errors.Str("CRC mismatch")
-	}
 	if fr == nil {
 		return 0, errors.Str("nil frame received")
 	}

--- a/pool/static_pool_test.go
+++ b/pool/static_pool_test.go
@@ -23,8 +23,8 @@ import (
 
 var cfg = &Config{
 	NumWorkers:      uint64(runtime.NumCPU()),
-	AllocateTimeout: time.Second * 5,
-	DestroyTimeout:  time.Second * 5,
+	AllocateTimeout: time.Second * 500,
+	DestroyTimeout:  time.Second * 500,
 }
 
 func Test_NewPool(t *testing.T) {
@@ -558,6 +558,19 @@ func Test_Static_Pool_WrongCommand2(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, p)
+}
+
+func Test_CRC_WithPayload(t *testing.T) {
+	ctx := context.Background()
+	_, err := Initialize(
+		ctx,
+		func() *exec.Cmd { return exec.Command("php", "../tests/crc_error.php") },
+		pipe.NewPipeFactory(),
+		cfg,
+	)
+	assert.Error(t, err)
+	data := err.Error()
+	assert.Contains(t, data, "warning: some weird php erro")
 }
 
 /* PTR:

--- a/tests/crc_error.php
+++ b/tests/crc_error.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Spiral\Goridge\StreamRelay;
+use Spiral\RoadRunner\Worker as RoadRunner;
+
+require __DIR__ . "/vendor/autoload.php";
+
+fwrite(STDOUT, "warning: some weird php error");
+
+$rr = new RoadRunner(new StreamRelay(\STDIN, \STDOUT));
+
+while($rr->waitPayload()){
+    sleep(3);
+    $rr->respond(new \Spiral\RoadRunner\Payload(""));
+}

--- a/transport/pipe/pipe_factory_spawn_test.go
+++ b/transport/pipe/pipe_factory_spawn_test.go
@@ -338,7 +338,7 @@ func Test_String2(t *testing.T) {
 
 	assert.Contains(t, w.String(), "php ../../tests/client.php echo pipes")
 	assert.Contains(t, w.String(), "ready")
-	assert.Contains(t, w.String(), "numExecs: 0")
+	assert.Contains(t, w.String(), "num_execs: 0")
 }
 
 func Test_Echo_Slow2(t *testing.T) {

--- a/transport/pipe/pipe_factory_test.go
+++ b/transport/pipe/pipe_factory_test.go
@@ -397,7 +397,7 @@ func Test_String(t *testing.T) {
 
 	assert.Contains(t, w.String(), "php ../../tests/client.php echo pipes")
 	assert.Contains(t, w.String(), "ready")
-	assert.Contains(t, w.String(), "numExecs: 0")
+	assert.Contains(t, w.String(), "num_execs: 0")
 }
 
 func Test_Echo_Slow(t *testing.T) {

--- a/worker/sync_worker.go
+++ b/worker/sync_worker.go
@@ -190,11 +190,7 @@ func (tw *SyncWorkerImpl) execPayload(p *payload.Payload) (*payload.Payload, err
 		return nil, errors.E(op, errors.Network, err)
 	}
 	if frameR == nil {
-		return nil, errors.E(op, errors.Network, errors.Str("nil fr received"))
-	}
-
-	if !frameR.VerifyCRC(frameR.Header()) {
-		return nil, errors.E(op, errors.Network, errors.Str("failed to verify CRC"))
+		return nil, errors.E(op, errors.Network, errors.Str("nil frame received"))
 	}
 
 	flags := frameR.ReadFlags()

--- a/worker/sync_worker_test.go
+++ b/worker/sync_worker_test.go
@@ -14,7 +14,7 @@ func Test_NotStarted_String(t *testing.T) {
 	w, _ := InitBaseWorker(cmd)
 	assert.Contains(t, w.String(), "php tests/client.php echo pipes")
 	assert.Contains(t, w.String(), "inactive")
-	assert.Contains(t, w.String(), "numExecs: 0")
+	assert.Contains(t, w.String(), "num_execs: 0")
 }
 
 func Test_NotStarted_Exec(t *testing.T) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -111,7 +111,7 @@ func (w *Process) String() string {
 	}
 
 	return fmt.Sprintf(
-		"(`%s` [%s], numExecs: %v)",
+		"(`%s` [%s], num_execs: %v)",
 		strings.Join(w.cmd.Args, " "),
 		st,
 		w.state.NumExecs(),


### PR DESCRIPTION
- closes: #829 

## Description of Changes

- Update goridge to v3.2.4.
- Print bad header in case of CRC error.

NOTE!:
The bad header contains only 12-14 bytes depending on the message. For example, if you (or PHP) print some message before workers start into the STDOUT (RR communication channel), the message would be shrunk to 12-14 bytes (RR header size). In case of the original message: `warning: some weird php error`, you'll see only `warning: some weird php erro`, but it's better than nothing. At least, the user can get a hint, where the error occurred.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
