### PR TITLE
bug(pool,ww): unstopped ticker causes a memory leak

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ["7.4", "8.0", "8.1"]
-        go: ["1.17.4"]
+        go: ["1.17.5"]
         os: ["ubuntu-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+# v2.6.1 (14.12.2021)
+
+## 🩹 Fixes:
+
+- 🐛 Fix: memory leak when supervised static pool used. [PR](https://github.com/spiral/roadrunner/pull/870).
+
+
 # v2.6.0 (30.11.2021)
 
 ### 👀 New:

--- a/pool/supervisor_pool.go
+++ b/pool/supervisor_pool.go
@@ -87,8 +87,10 @@ func (sp *supervised) RemoveWorker(worker worker.BaseProcess) error {
 }
 
 func (sp *supervised) Destroy(ctx context.Context) {
-	sp.pool.Destroy(ctx)
 	sp.Stop()
+	sp.mu.Lock()
+	sp.pool.Destroy(ctx)
+	sp.mu.Unlock()
 }
 
 func (sp *supervised) Start() {

--- a/pool/supervisor_pool.go
+++ b/pool/supervisor_pool.go
@@ -54,12 +54,16 @@ func (sp *supervised) execWithTTL(_ context.Context, _ *payload.Payload) (*paylo
 func (sp *supervised) Exec(rqs *payload.Payload) (*payload.Payload, error) {
 	const op = errors.Op("supervised_exec_with_context")
 	if sp.cfg.ExecTTL == 0 {
+		sp.mu.RLock()
+		defer sp.mu.RUnlock()
 		return sp.pool.Exec(rqs)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), sp.cfg.ExecTTL)
 	defer cancel()
 
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
 	res, err := sp.pool.execWithTTL(ctx, rqs)
 	if err != nil {
 		return nil, errors.E(op, err)

--- a/pool/supervisor_pool.go
+++ b/pool/supervisor_pool.go
@@ -84,15 +84,17 @@ func (sp *supervised) RemoveWorker(worker worker.BaseProcess) error {
 
 func (sp *supervised) Destroy(ctx context.Context) {
 	sp.pool.Destroy(ctx)
+	sp.Stop()
 }
 
 func (sp *supervised) Start() {
 	go func() {
 		watchTout := time.NewTicker(sp.cfg.WatchTick)
+		defer watchTout.Stop()
+
 		for {
 			select {
 			case <-sp.stopCh:
-				watchTout.Stop()
 				return
 			// stop here
 			case <-watchTout.C:


### PR DESCRIPTION
# Reason for This PR

- A lot of allocated memory when `supervised` pool with often workers restarts used.

## Description of Changes

- Stop the ticker on the pool's destroy call.
- Properly lock-unlock the destroy mutex in the worker_watcher
- Supervisor is now synchronized with the check workers loop (which actually checks the memory, ttl, etc).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
