### PR TITLE
bug(static_pool, debug mode): worker exited immediately after obtaining the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # CHANGELOG
 
+# v2.6.2 (15.12.2021)
+
+## 🩹 Fixes:
+
+- 🐛 Fix: worker exited immediately after obtaining the response. [BUG](https://github.com/spiral/roadrunner/issues/871) (reporter: @samdark).
+
+---
+
 # v2.6.1 (14.12.2021)
 
 ## 🩹 Fixes:
 
 - 🐛 Fix: memory leak when supervised static pool used. [PR](https://github.com/spiral/roadrunner/pull/870).
 
+---
 
 # v2.6.0 (30.11.2021)
 
@@ -17,6 +26,8 @@
 ## 🩹 Fixes:
 
 - 🐛 Fix: zombie processes in the `pool.debug` mode.
+
+---
 
 # v2.5.1 (07.11.2021)
 

--- a/events/events.go
+++ b/events/events.go
@@ -25,6 +25,8 @@ const (
 	EventWorkerStderr
 	// EventWorkerWaitExit is the worker exit event
 	EventWorkerWaitExit
+	// EventWorkerStopped triggered when worker gracefully stopped
+	EventWorkerStopped
 )
 
 func (et EventType) String() string {
@@ -51,7 +53,8 @@ func (et EventType) String() string {
 		return "EventWorkerStderr"
 	case EventWorkerWaitExit:
 		return "EventWorkerWaitExit"
-
+	case EventWorkerStopped:
+		return "EventWorkerStopped"
 	default:
 		return "UnknownEventType"
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
+	golang.org/x/sys v0.0.0-20211214170744-3b038e5940ed // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cO
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211214170744-3b038e5940ed h1:d5glpD+GMms2DMbu1doSYibjbKasYNvnhq885nOnRz8=
+golang.org/x/sys v0.0.0-20211214170744-3b038e5940ed/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -4,13 +4,11 @@ import (
 	"os"
 	"sync"
 
-	j "github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"github.com/spiral/errors"
 	"github.com/spiral/goridge/v3/pkg/frame"
 	"github.com/spiral/goridge/v3/pkg/relay"
 )
-
-var json = j.ConfigCompatibleWithStandardLibrary
 
 type StopCommand struct {
 	Stop bool `json:"stop"`

--- a/pool/static_pool.go
+++ b/pool/static_pool.go
@@ -318,7 +318,6 @@ func (sp *StaticPool) execDebug(p *payload.Payload) (*payload.Payload, error) {
 	}()
 
 	// destroy the worker
-	sw.State().Set(worker.StateDestroyed)
 	err = sw.Stop()
 	if err != nil {
 		sp.events.Send(events.NewEvent(events.EventWorkerError, pluginName, fmt.Sprintf("error: %s, worker's pid: %d", err, sw.Pid())))
@@ -346,9 +345,10 @@ func (sp *StaticPool) execDebugWithTTL(ctx context.Context, p *payload.Payload) 
 		_ = sw.Wait()
 	}()
 
-	sw.State().Set(worker.StateDestroyed)
-	if stopErr := sw.Stop(); stopErr != nil {
-		sp.events.Send(events.NewEvent(events.EventWorkerError, pluginName, fmt.Sprintf("error: %s, pid: %d", err, sw.Pid())))
+	err = sw.Stop()
+	if err != nil {
+		sp.events.Send(events.NewEvent(events.EventWorkerError, pluginName, fmt.Sprintf("error: %s, worker's pid: %d", err, sw.Pid())))
+		return nil, err
 	}
 
 	return r, err

--- a/pool/supervisor_test.go
+++ b/pool/supervisor_test.go
@@ -211,18 +211,21 @@ func TestSupervisedPool_Idle(t *testing.T) {
 		Body:    []byte("foo"),
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, resp.Body)
 	assert.Empty(t, resp.Context)
 
 	time.Sleep(time.Second * 5)
 
 	// worker should be marked as invalid and reallocated
-	_, err = p.Exec(&payload.Payload{
+	rsp, err := p.Exec(&payload.Payload{
 		Context: []byte(""),
 		Body:    []byte("foo"),
 	})
 	assert.NoError(t, err)
+	require.NotNil(t, rsp)
+	time.Sleep(time.Second * 2)
+	require.Len(t, p.Workers(), 1)
 	// should be new worker with new pid
 	assert.NotEqual(t, pid, p.Workers()[0].Pid())
 	p.Destroy(context.Background())

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -44,7 +44,8 @@ type Process struct {
 
 	// pid of the process, points to pid of underlying process and
 	// can be nil while process is not started.
-	pid int
+	pid    int
+	doneCh chan struct{}
 
 	// communication bus with underlying process.
 	relay relay.Relay
@@ -63,6 +64,7 @@ func InitBaseWorker(cmd *exec.Cmd, options ...Options) (*Process, error) {
 		eventsID: id,
 		cmd:      cmd,
 		state:    NewWorkerState(StateInactive),
+		doneCh:   make(chan struct{}, 1),
 	}
 
 	// set self as stderr implementation (Writer interface)
@@ -136,6 +138,7 @@ func (w *Process) Wait() error {
 	var err error
 	err = w.cmd.Wait()
 	defer w.events.Unsubscribe(w.eventsID)
+	w.doneCh <- struct{}{}
 
 	// If worker was destroyed, just exit
 	if w.State().Value() == StateDestroyed {
@@ -180,18 +183,25 @@ func (w *Process) closeRelay() error {
 func (w *Process) Stop() error {
 	const op = errors.Op("process_stop")
 	w.state.Set(StateStopping)
-	err := internal.SendControl(w.relay, &internal.StopCommand{Stop: true})
-	if err != nil {
-		w.state.Set(StateKilling)
-		_ = w.cmd.Process.Signal(os.Kill)
+	select {
+	// finished
+	case <-w.doneCh:
+		return nil
+	default:
+		err := internal.SendControl(w.relay, &internal.StopCommand{Stop: true})
+		if err != nil {
+			w.state.Set(StateKilling)
+			_ = w.cmd.Process.Signal(os.Kill)
 
+			w.events.Unsubscribe(w.eventsID)
+			return errors.E(op, errors.Network, err)
+		}
+
+		<-w.doneCh
+		w.state.Set(StateStopped)
 		w.events.Unsubscribe(w.eventsID)
-		return errors.E(op, errors.Network, err)
+		return nil
 	}
-
-	w.state.Set(StateStopped)
-	w.events.Unsubscribe(w.eventsID)
-	return nil
 }
 
 // Kill kills underlying process, make sure to call Wait() func to gather


### PR DESCRIPTION
# Reason for This PR

closes: #871 

## Description of Changes

- Prevent workers from the exit by waiting for the process after the stop command.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
