### PR TITLE
feat(pool): add `Reset` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+# v2.6.3 (23.12.2021)
+
+## 👀 New:
+
+- ✏️ Add `Reset` method to the static pool interface. Should be used to reset the pool instead of destroying and replacing it.
+
+---
+
 # v2.6.2 (15.12.2021)
 
 ## 🩹 Fixes:

--- a/pool/interface.go
+++ b/pool/interface.go
@@ -21,6 +21,9 @@ type Pool interface {
 	// RemoveWorker removes worker from the pool.
 	RemoveWorker(worker worker.BaseProcess) error
 
+	// Reset kill all workers inside the watcher and replaces with new
+	Reset(ctx context.Context) error
+
 	// Destroy all underlying stack (but let them to complete the task).
 	Destroy(ctx context.Context)
 
@@ -44,6 +47,9 @@ type Watcher interface {
 
 	// Destroy destroys the underlying container
 	Destroy(ctx context.Context)
+
+	// Reset will replace container and workers array, kill all workers
+	Reset(ctx context.Context)
 
 	// List return all container w/o removing it from internal storage
 	List() []worker.BaseProcess

--- a/pool/supervisor_pool.go
+++ b/pool/supervisor_pool.go
@@ -51,6 +51,12 @@ func (sp *supervised) execWithTTL(_ context.Context, _ *payload.Payload) (*paylo
 	panic("used to satisfy pool interface")
 }
 
+func (sp *supervised) Reset(ctx context.Context) error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.pool.Reset(ctx)
+}
+
 func (sp *supervised) Exec(rqs *payload.Payload) (*payload.Payload, error) {
 	const op = errors.Op("supervised_exec_with_context")
 	if sp.cfg.ExecTTL == 0 {

--- a/pool/supervisor_test.go
+++ b/pool/supervisor_test.go
@@ -58,6 +58,33 @@ func TestSupervisedPool_Exec(t *testing.T) {
 	p.Destroy(context.Background())
 }
 
+func Test_SupervisedPoolReset(t *testing.T) {
+	ctx := context.Background()
+	p, err := Initialize(
+		ctx,
+		func() *exec.Cmd { return exec.Command("php", "../tests/client.php", "echo", "pipes") },
+		pipe.NewPipeFactory(),
+		cfgSupervised,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+
+	w := p.Workers()
+	if len(w) == 0 {
+		t.Fatal("should be workers inside")
+	}
+
+	pid := w[0].Pid()
+	require.NoError(t, p.Reset(context.Background()))
+
+	w2 := p.Workers()
+	if len(w2) == 0 {
+		t.Fatal("should be workers inside")
+	}
+
+	require.NotEqual(t, pid, w2[0].Pid())
+}
+
 // This test should finish without freezes
 func TestSupervisedPool_ExecWithDebugMode(t *testing.T) {
 	var cfgSupervised = cfgSupervised

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -223,7 +223,6 @@ func (w *Process) Kill() error {
 		return err
 	}
 	w.state.Set(StateStopped)
-
 	w.events.Unsubscribe(w.eventsID)
 	return nil
 }

--- a/worker_watcher/container/channel/vec.go
+++ b/worker_watcher/container/channel/vec.go
@@ -98,15 +98,16 @@ func (v *Vec) Push(w worker.BaseProcess) {
 func (v *Vec) Remove(_ int64) {}
 
 func (v *Vec) Pop(ctx context.Context) (worker.BaseProcess, error) {
-	/*
-		if *addr == old {
-			*addr = new
-			return true
-		}
-	*/
-
 	if atomic.LoadUint64(&v.destroy) == 1 {
-		return nil, errors.E(errors.WatcherStopped)
+		// drain channel
+		for {
+			select {
+			case <-v.workers:
+				continue
+			default:
+				return nil, errors.E(errors.WatcherStopped)
+			}
+		}
 	}
 
 	// used only for the TTL-ed workers


### PR DESCRIPTION
# Reason for This PR

- Use the `Reset` method instead of replacing the pool every time.

## Description of Changes

- ✏️ Add `Reset` method to the static pool interface. Should be used to reset the pool instead of destroying and replacing it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
