### PR TITLE
feat(releases): add `FreeBSD/amd64` build to GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
             compiler: gcc
             archiver: tar
             arch: arm64
+          - os: freebsd
+            compiler: gcc
+            archiver: tar
+            arch: amd64
           - os: darwin
             compiler: gcc
             archiver: tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v2.7.10 (15.02.2022)
+
+## 👀 New:
+
+- ✏️ Add build for FreeBSD/amd64
+
+---
+
 ## v2.7.9 (14.02.2022)
 
 ## 🩹 Fixes:


### PR DESCRIPTION
# Reason for This PR

We're using RoadRunner on FreeBSD and would like to have official builds as well.

## Description of Changes

Added FreeBSD/amd64 build to GitHub Actions release workflow.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
