### PR TITLE
release: `v2.8.3` 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.7
+          go-version: 1.17.8
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release_grpc.yml
+++ b/.github/workflows/release_grpc.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.7
+          go-version: 1.17.8
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      
-      - name: Set up Go 1.17
+
+      - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.17.7
+          go-version: 1.17.8
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0 # Action page: <https://github.com/golangci/golangci-lint-action>
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.7
+          go-version: 1.17.8
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.17.7
+          go-version: 1.17.8
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+## UNRELEASED
+
+## 👀 New:
+
+- ✏️ [**API**](https://github.com/roadrunner-server/api): add service proto api to manage services, [FR](https://github.com/roadrunner-server/roadrunner/issues/1009) (reporter @butschster)
+
+
+## v2.8.3 (13.03.2022)
+
+## 👀 New:
+
+- ✏️ Better env variables parser. Now RR is able to parse the sentences like: `"mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverVersion=5.7"` and get all environment variables. [FR](https://github.com/roadrunner-server/roadrunner/issues/1035), (reporter @Tony-Sol)
+
+## 🧹 Chore:
+
+- 🧑‍🏭 Update all dependencies to the most recent versions.
+- 🧑‍🏭 Remove `configuration` plugin from the `root.go` and other files. Used only in the `serve` where it should be.
+
+## 🩹 Fixes:
+
+- 🐛 Fix: call of the `kv.TTL` for the Redis drivers returns non RFC3339 time format [BUG](https://github.com/roadrunner-server/roadrunner/issues/1024), (reporter @antikirra)
+- 🐛 Fix: `rr workers` command doesn't work for the `service` plugin [BUG](https://github.com/roadrunner-server/roadrunner/issues/1033), (reporter @OO00O0O)
+
+---
+
 ## v2.8.2 (22.02.2022)
 
 ## 🧹 Chore:


### PR DESCRIPTION
# Reason for This PR

- Bugfix release cycle.

## Description of Changes

## 👀 New:

- ✏️ Better env variables parser. Now RR is able to parse the sentences like: `"mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverVersion=5.7"` and get all environment variables. [FR](https://github.com/roadrunner-server/roadrunner/issues/1035), (reporter @Tony-Sol)

## 🧹 Chore:

- 🧑‍🏭 Update all dependencies to the most recent versions.
- 🧑‍🏭 Remove `configuration` plugin from the `root.go` and other files. Used only in the `serve` where it should be.

## 🩹 Fixes:

- 🐛 Fix: call of the `kv.TTL` for the Redis drivers returns non RFC3339 time format [BUG](https://github.com/roadrunner-server/roadrunner/issues/1024), (reporter @antikirra)
- 🐛 Fix: `rr workers` command doesn't work for the `service` plugin [BUG](https://github.com/roadrunner-server/roadrunner/issues/1033), (reporter @OO00O0O)


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
