### PR TITLE
linters: use go 1.17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.18
+          go-version: 1.17
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.45 # without patch version
+          version: v1.44 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --build-tags=safe --timeout=10m
 


### PR DESCRIPTION
# Reason for This PR

- golangci-lint fails to run on go 1.18

## Description of Changes

- Downgrade go version for the linters

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
