### PR TITLE
chore(work_dir): change wd before searching for the config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.18
+          go-version: 1.17
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.44 # without patch version
+          version: v1.45.1 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --build-tags=safe --timeout=10m
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.45 # without patch version
+          version: v1.44 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --build-tags=safe --timeout=10m
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.18
+          go-version: 1.17
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.44 # without patch version
+          version: v1.45 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --build-tags=safe --timeout=10m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 # Documentation: <https://github.com/golangci/golangci-lint#config-file>
 
 run:
+  go: '1.17'
   timeout: 1m
   skip-dirs:
     - .github

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # Documentation: <https://github.com/golangci/golangci-lint#config-file>
 
 run:
-  go: '1.17'
   timeout: 1m
   skip-dirs:
     - .github

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,17 +46,17 @@ func NewCommand(cmdName string) *cobra.Command { //nolint:funlen
 				return errors.Str("no configuration file provided")
 			}
 
+			if workDir != "" {
+				if err := os.Chdir(workDir); err != nil {
+					return err
+				}
+			}
+
 			if absPath, err := filepath.Abs(*cfgFile); err == nil {
 				*cfgFile = absPath // switch config path to the absolute
 
 				// force working absPath related to config file
 				if err = os.Chdir(filepath.Dir(absPath)); err != nil {
-					return err
-				}
-			}
-
-			if workDir != "" {
-				if err := os.Chdir(workDir); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
# Reason for This PR

- Some users may experience issues when using a work-dir option with relative paths for the config.

## Description of Changes

- Switch to a user-specified working directory before building the absolute path to the configuration file.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
