### PR TITLE
release: `v2.10.1`

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -800,8 +800,13 @@ http:
 
     # Path to the root certificate authority file.
     #
-    # This option is optional.
+    # This option is optional (required for the mTLS).
     root_ca: /ssl/root.crt
+
+    # Client auth type (mTLS)
+    #
+    # This option is optional. Default value: no_client_certs. Possible values: request_client_cert, require_any_client_cert, verify_client_cert_if_given, require_and_verify_client_cert, no_client_certs
+    client_auth_type: no_client_certs
 
   # FastCGI frontend support.
   fcgi:

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -1178,6 +1178,11 @@ jobs:
         # If the job has priority set to 0, it will inherit the pipeline's priority. Default: 10.
         priority: 1
 
+        # Consume any payload type (not only Jobs structured)
+        #
+        # Default: false
+        consume_all: false
+
         # Durable queue
         #
         # Default: false
@@ -1246,6 +1251,11 @@ jobs:
         # Default: 1
         tube_priority: 1
 
+        # Consume any payload type (not only Jobs structured)
+        #
+        # Default: false
+        consume_all: false
+
         # Tube name
         #
         # Default: default
@@ -1277,6 +1287,16 @@ jobs:
         #
         # Default: 10
         prefetch: 10
+
+        # Consume any payload type (not only Jobs structured)
+        #
+        # Default: false
+        consume_all: false
+
+        # Get queue URL only
+        #
+        # Default: false
+        skip_queue_declaration: false
 
         # The duration (in seconds) that the received messages are hidden from subsequent
         # retrieve requests after being retrieved by a ReceiveMessage request
@@ -1319,7 +1339,6 @@ jobs:
       #
       # Should not be empty
       config:
-
         # Pipeline priority
         #
         # If the job has priority set to 0, it will inherit the pipeline's priority. Default: 10.
@@ -1329,6 +1348,11 @@ jobs:
         #
         # Messages to read into the channel
         prefetch: 100
+
+        # Consume any payload type (not only Jobs structured)
+        #
+        # Default: false
+        consume_all: false
 
         # NATS subject
         #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,99 @@
 # CHANGELOG
 
+## v2.10.1 (19.05.2022)
+
+## 👀 New:
+- ✏️ **Jobs (queues)** plugin now can consume any payload from the queue. If RR fails in converting payload into the `Job` structure, it'll create and fill all available fields manually. To turn **on** this feature, use `consume_all: true` in the driver configuration, e.g.:
+Supported drivers: `amqp`, `sqs`,`beanstalk`,`nats`.
+
+```yaml
+jobs:
+  num_pollers: 10
+  pipeline_size: 100000
+  pool:
+    num_workers: 10
+
+  pipelines:
+    test-raw:
+      driver: sqs
+      config:
+        consume_all: true # <------- NEW OPTION
+
+  consume: [ "test-raw" ]
+```
+
+- ✏️ **SQS** Jobs driver now can skip queue declaration in favor of getting queue URL instead. To use this feature, use `skip_queue_declaration: true` sqs driver option. [FR](https://github.com/roadrunner-server/roadrunner/issues/980), (thanks @sergey-telpuk)
+
+```yaml
+jobs:
+  num_pollers: 10
+  pipeline_size: 100000
+  pool:
+    num_workers: 10
+
+  pipelines:
+    test-2:
+      driver: sqs
+      config:
+        skip_queue_declaration: true # <----- NEW OPTION
+
+  consume: [ "test-2" ]
+```
+
+- ✏️ OpenTelemetry middleware now supports `Jaeger` exporter and propagator.
+
+```yaml
+http:
+  address: 127.0.0.1:43239
+  max_request_size: 1024
+  middleware: [gzip, otel]
+  pool:
+    num_workers: 2
+    max_jobs: 0
+    allocate_timeout: 60s
+    destroy_timeout: 60s
+
+otel:
+  exporter: jaeger # <----- NEW OPTION
+```
+
+- ✏️ **HTTP Plugin** now supports [`mTLS` authentication](https://www.cloudflare.com/en-gb/learning/access-management/what-is-mutual-tls/). Possible values for the `client_auth_type` are the same as for the `gRPC` (`no_client_cert`, `request_client_cert`,`require_any_client_cert`,`verify_client_cert_if_given`,`require_and_verify_client_cert`) [FR](https://github.com/roadrunner-server/roadrunner/issues/1111), (thanks @fwolfsjaeger)
+
+```yaml
+version: '2.7'
+
+server:
+  command: "php ../../php_test_files/http/client.php echo pipes"
+  relay: "pipes"
+  relay_timeout: "20s"
+
+http:
+  address: :8085
+  max_request_size: 1024
+  middleware: [ ]
+  pool:
+    num_workers: 1
+    max_jobs: 0
+    allocate_timeout: 60s
+    destroy_timeout: 60s
+  ssl:
+    address: :8895
+    key: "key"
+    cert: "cert"
+    root_ca: "rootCA.pem" # <---- REQUIRED to use mTLS
+    client_auth_type: require_and_verify_client_cert # <---- NEW OPTION
+logs:
+  mode: development
+  level: error
+```
+
+## 🩹 Fixes:
+
+- 🐛 Fix: **HTTP plugin**: non-documented behavior on non-standard (but valid) http codes. [BUG](https://github.com/roadrunner-server/roadrunner/issues/1136), (thanks, @Meroje)
+- 🐛 Fix: **SQS driver**: `rr_auto_ack` attribute won't fail the existing messages.
+
+---
+
 ## v2.10.0 (16.05.2022)
 
 ## 👀 New:

--- a/schemas/config/2.0.schema.json
+++ b/schemas/config/2.0.schema.json
@@ -1175,6 +1175,11 @@
                                                     "type": "integer",
                                                     "default": 100000
                                                 },
+                                                "consume_all": {
+                                                    "description": "Consume all payloads, even not Job structured",
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
                                                 "queue": {
                                                     "type": "string",
                                                     "description": "Queue name",
@@ -1238,6 +1243,11 @@
                                                     "type": "integer",
                                                     "default": 100000
                                                 },
+                                                "consume_all": {
+                                                    "description": "Consume all payloads, even not Job structured",
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
                                                 "tube_priority": {
                                                     "description": "Beanstalk internal tube priority",
                                                     "type": "integer",
@@ -1266,6 +1276,16 @@
                                                     "description": "Number of job to prefetch from the driver",
                                                     "type": "integer",
                                                     "default": 100000
+                                                },
+                                                "skip_queue_declaration": {
+                                                    "description": "Get queue URL instead of declaring it",
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "consume_all": {
+                                                    "description": "Consume all payloads, even not Job structured",
+                                                    "type": "boolean",
+                                                    "default": false
                                                 },
                                                 "visibility_timeout": {
                                                     "type": "integer",
@@ -1315,6 +1335,11 @@
                                                     "description": "Number of job to prefetch from the driver",
                                                     "type": "integer",
                                                     "default": 100000
+                                                },
+                                                "consume_all": {
+                                                    "description": "Consume all payloads, even not Job structured",
+                                                    "type": "boolean",
+                                                    "default": false
                                                 },
                                                 "subject": {
                                                     "description": "NATS subject",

--- a/schemas/config/2.0.schema.json
+++ b/schemas/config/2.0.schema.json
@@ -692,6 +692,18 @@
                             "examples": [
                                 "/ssl/root.crt"
                             ]
+                        },
+                        "client_auth_type": {
+                            "description": "Client auth type",
+                            "type": "string",
+                            "default": "no_client_certs",
+                            "enum": [
+                                "request_client_cert",
+                                "require_any_client_cert",
+                                "verify_client_cert_if_given",
+                                "no_client_certs",
+                                "require_and_verify_client_cert"
+                            ]
                         }
                     },
                     "required": [


### PR DESCRIPTION
# Reason for This PR

- next release cycle.
- tests: https://github.com/roadrunner-server/rr-e2e-tests/releases/tag/v2.10.1

## Description of Changes

## 👀 New:
- ✏️ **Jobs (queues)** plugin now can consume any payload from the queue. If RR fails in converting payload into the `Job` structure, it'll create and fill all available fields manually. To turn **on** this feature, use `consume_all: true` in the driver configuration, e.g.:
Supported drivers: `amqp`, `sqs`,`beanstalk`,`nats`.

```yaml
jobs:
  num_pollers: 10
  pipeline_size: 100000
  pool:
    num_workers: 10

  pipelines:
    test-raw:
      driver: sqs
      config:
        consume_all: true # <------- NEW OPTION

  consume: [ "test-raw" ]
```

- ✏️ **SQS** Jobs driver now can skip queue declaration in favor of getting queue URL instead. To use this feature, use `skip_queue_declaration: true` sqs driver option. [FR](https://github.com/roadrunner-server/roadrunner/issues/980)

```yaml
jobs:
  num_pollers: 10
  pipeline_size: 100000
  pool:
    num_workers: 10

  pipelines:
    test-2:
      driver: sqs
      config:
        skip_queue_declaration: true # <----- NEW OPTION

  consume: [ "test-2" ]
```

- ✏️ OpenTelemetry middleware now supports `Jaeger` exporter and propagator.

```yaml
http:
  address: 127.0.0.1:43239
  max_request_size: 1024
  middleware: [gzip, otel]
  pool:
    num_workers: 2
    max_jobs: 0
    allocate_timeout: 60s
    destroy_timeout: 60s

otel:
  exporter: jaeger # <----- NEW OPTION
```

- ✏️ **HTTP Plugin** now supports [`mTLS` authentication](https://www.cloudflare.com/en-gb/learning/access-management/what-is-mutual-tls/). Possible values for the `client_auth_type` are the same as for the `gRPC` (`no_client_cert`, `request_client_cert`,`require_any_client_cert`,`verify_client_cert_if_given`,`require_and_verify_client_cert`) [FR](https://github.com/roadrunner-server/roadrunner/issues/1111)

```yaml
version: '2.7'

server:
  command: "php ../../php_test_files/http/client.php echo pipes"
  relay: "pipes"
  relay_timeout: "20s"

http:
  address: :8085
  max_request_size: 1024
  middleware: [ ]
  pool:
    num_workers: 1
    max_jobs: 0
    allocate_timeout: 60s
    destroy_timeout: 60s
  ssl:
    address: :8895
    key: "key"
    cert: "cert"
    root_ca: "rootCA.pem" # <---- REQUIRED to use mTLS
    client_auth_type: require_and_verify_client_cert # <---- NEW OPTION
logs:
  mode: development
  level: error
```

## 🩹 Fixes:

- 🐛 Fix: **HTTP plugin**: non-documented behavior on non-standard (but valid) http codes. [BUG](https://github.com/roadrunner-server/roadrunner/issues/1136)
- 🐛 Fix: **SQS driver**: `rr_auto_ack` attribute won't fail the existing messages.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
