### PR TITLE
chore: update grpc default address

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -1637,7 +1637,7 @@ grpc:
   # GRPC address to listen
   #
   # This option is required
-  listen: "tcp://localhost:9001"
+  listen: "tcp://127.0.0.1:9001"
 
   # Proto file to use, multiply files supported [SINCE 2.6]
   #


### PR DESCRIPTION
# Reason for This PR

In some cases `localhost` causes the error below

```
handle_serve_command: Serve error:
        endure_start:
        endure_serve_internal: Function call error:
        endure_call_serve_fn: got initial serve error from the Vertex grpc.Plugin, stopping execution, error: grpc_plugin_serve: address localhost: no suitable address found
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
