### PR TITLE
pre-release: `v2.12.0-rc.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # CHANGELOG
 
+## v2.12.0-rc.1 (12.11.2022)
+
+## 👀 New:
+
+- ✏ **All plugins**: update to `v3`. This is done not because of some breaking change but because of the internal update.
+- ✏ **RPC plugin**: add new API to provide a running RR version and RR configuration in JSON format.
+- ✏ **AMQP plugin**: new configuration options. [FR](https://github.com/roadrunner-server/roadrunner/issues/1351), (thanks @andrey-tech)
+```yaml
+jobs:
+  pipelines:
+    example:
+      driver: amqp
+      config:
+        # Durable exchange
+        #
+        # Default: true
+        exchange_durable: true
+
+        # Auto-deleted exchange
+        #
+        # Default: false
+        exchange_auto_deleted: false
+
+        # Auto-deleted queue
+        #
+        # Default: false
+        queue_auto_deleted: false
+```
+
+- ✏ **Workers pool (SDK)**: New option to control the `reset_timeout`. Note that the `pool.Reset` is protected by mutexes, meaning that if you have some requests already in the pool, you'll have to wait for these requests to be processed. The `reset_timeout` does not count this time.
+
+```yaml
+pool:
+  allocate_timeout: 10s
+  reset_timeout: 10s
+  destroy_timeout: 10s
+```
+
+---
+
 ## v2.12.0-beta.1 (03.11.2022)
 
 # ⚠️ `websocket` and `broadcast` plugins was replaced by the new `centrifuge` plugin.

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,7 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 h1:fi9bGIUJOGzzrHBbP8NWbTfNC5fKO6X7kFw40TOqGB8=

--- a/schemas/config/2.0.schema.json
+++ b/schemas/config/2.0.schema.json
@@ -1436,6 +1436,21 @@
                                                     "type": "string",
                                                     "default": "amqp.default"
                                                 },
+                                                "exchange_durable": {
+                                                    "description": "Durable exchange",
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "exchange_auto_deleted": {
+                                                    "description": "Auto delete exchange",
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
+                                                "queue_auto_deleted": {
+                                                    "description": "Queue auto delete",
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
                                                 "exchange_type": {
                                                     "description": "Exchange type",
                                                     "type": "string",
@@ -2135,12 +2150,17 @@
                     "default": 0
                 },
                 "allocate_timeout": {
-                    "description": "Timeout for worker allocation. Zero means no limit",
+                    "description": "Timeout for worker allocation. Zero means the default limit - 60s",
+                    "$ref": "#/definitions/Duration",
+                    "default": "60s"
+                },
+                "reset_timeout": {
+                    "description": "Timeout for the pool.Reset operation (./rr reset). Zero means the default limit - 60s",
                     "$ref": "#/definitions/Duration",
                     "default": "60s"
                 },
                 "destroy_timeout": {
-                    "description": "Timeout for worker destroying before process killing. Zero means no limit",
+                    "description": "Timeout for worker destroying before process killing. Zero means the default limit - 60s",
                     "$ref": "#/definitions/Duration",
                     "default": "60s"
                 },


### PR DESCRIPTION
# Reason for This PR

- release cycle.

## Description of Changes

## 👀 New:

- ✏ **All plugins**: update to `v3`. This is done not because of some breaking change but because of the internal update.
- ✏ **RPC plugin**: add new API to provide a running RR version and RR configuration in JSON format.
- ✏ **AMQP plugin**: new configuration options. [FR](https://github.com/roadrunner-server/roadrunner/issues/1351), (thanks @andrey-tech)
```yaml
jobs:
  pipelines:
    example:
      driver: amqp
      config:
        # Durable exchange
        #
        # Default: true
        exchange_durable: true

        # Auto-deleted exchange
        #
        # Default: false
        exchange_auto_deleted: false

        # Auto-deleted queue
        #
        # Default: false
        queue_auto_deleted: false
```

- ✏ **Workers pool (SDK)**: New option to control the `reset_timeout`. Note that the `pool.Reset` is protected by mutexes, meaning that if you have some requests already in the pool, you'll have to wait for these requests to be processed. The `reset_timeout` does not count this time. [FR](https://github.com/roadrunner-server/roadrunner/issues/1352), (thanks @butschster)

```yaml
pool:
  allocate_timeout: 10s
  reset_timeout: 10s
  destroy_timeout: 10s
```


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
