### PR TITLE
release: `v2.12.0`

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -476,6 +476,11 @@ service:
     # Default: 0 (infinity), can be 1s, 2m, 2h (seconds, minutes, hours)
     exec_timeout: 0
 
+    # Show the name of the service in logs (e.g. service.some_service_1)
+    #
+    # Default: false
+    service_name_in_log: false
+
     # Remain process after exit. In other words, restart process after exit with any exit code.
     #
     # Default: "false"
@@ -506,6 +511,12 @@ service:
     #
     # Default: 1
     process_num: 1
+
+
+    # Show the name of the service in logs (e.g. service.some_service_1)
+    #
+    # Default: false
+    service_name_in_log: false
 
     # Allowed time before stop.
     #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## v2.12.0 (24.11.2022)
 
+# ⚠️ `websocket` and `broadcast` plugins was replaced by the new `centrifuge` plugin.
+# ⚠️ All plugins, `sdk` and `api` updated to `v3`. There are no breaking changes, we moved all Go code from the `api` to `sdk`.
+
 ## 👀 New:
 
 - ✏ **All plugins**: update to `v3`. This is done not because of some breaking change but because of the internal update.
 - ✏ **RPC plugin**: add new API to provide a running RR version and RR configuration in JSON format.
+- ✏ **Metrics plugin**: add new API to unregister previously registered collector. (thanks @butschster)
+- ✏ **Server plugin**: add new API to get statuses about the service and its child processes. (thanks @butschster)
+- ✏ **App logger plugin**: Application logger plugin, [FR](https://github.com/roadrunner-server/roadrunner/issues/1227) (thanks @wolfy-j)
+  **Docs**: [PHP-lib](https://github.com/roadrunner-php/app-logger)
 - ✏ **AMQP plugin**: new configuration options. [FR](https://github.com/roadrunner-server/roadrunner/issues/1351), (thanks @andrey-tech)
 ```yaml
 jobs:
@@ -38,14 +45,8 @@ pool:
   destroy_timeout: 10s
 ```
 
-# ⚠️ `websocket` and `broadcast` plugins was replaced by the new `centrifuge` plugin.
-
-# ⚠️ All plugins, `sdk` and `api` updated to `v3`. There are no breaking changes, we moved all Go code from the `api` to `sdk`.
-
-## 👀 New:
-
 - ✏ **Centrifugo plugin**: New `centrifugo` plugin. Which is going to replace existing `broadcast` + `websockets` plugins. [FR](https://github.com/roadrunner-server/roadrunner/issues/1134).
-**Docs**: [PHP-lib](https://github.com/roadrunner-php/centrifugo)
+  **Docs**: [PHP-lib](https://github.com/roadrunner-php/centrifugo)
 
 RoadRunner config:
 
@@ -98,10 +99,6 @@ centrifuge:
   # Optional, default: null (see default values)
   pool: {}
 ```
-
-- ✏ **App logger plugin**: Application logger plugin, [FR](https://github.com/roadrunner-server/roadrunner/issues/1227) (thanks @wolfy-j)
-**Docs**: [PHP-lib](https://github.com/roadrunner-php/app-logger)
-
 
 ## 🩹 Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.12.0 (24.11.2022)
 
-# ⚠️ `websocket` and `broadcast` plugins was replaced by the new `centrifuge` plugin.
+# ⚠️ `websocket` and `broadcast` plugins were replaced by the new `centrifuge` plugin.
 # ⚠️ All plugins, `sdk` and `api` updated to `v3`. There are no breaking changes, we moved all Go code from the `api` to `sdk`.
 
 ## 👀 New:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v2.12.0-rc.1 (12.11.2022)
+## v2.12.0 (24.11.2022)
 
 ## 👀 New:
 
@@ -37,10 +37,6 @@ pool:
   reset_timeout: 10s
   destroy_timeout: 10s
 ```
-
----
-
-## v2.12.0-beta.1 (03.11.2022)
 
 # ⚠️ `websocket` and `broadcast` plugins was replaced by the new `centrifuge` plugin.
 

--- a/go.sum
+++ b/go.sum
@@ -587,6 +587,7 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0 h1:t7uX3JBHdVwAi3G7sSSdbsk8NfgA+LnUS88V/2EKaA0=


### PR DESCRIPTION
# Reason for This PR

- release cycle.

## Description of Changes

# ⚠️ `websocket` and `broadcast` plugins were replaced by the new `centrifuge` plugin.
# ⚠️ All plugins, `sdk` and `api` updated to `v3`. There are no breaking changes, we moved all Go code from the `api` to `sdk`.

## 👀 New:

- ✏ **All plugins**: update to `v3`. This is done not because of some breaking change but because of the internal update.
- ✏ **RPC plugin**: add new API to provide a running RR version and RR configuration in JSON format.
- ✏ **Metrics plugin**: add new API to unregister previously registered collector. (thanks @butschster)
- ✏ **Server plugin**: add new API to get statuses about the service and its child processes. (thanks @butschster)
- ✏ **App logger plugin**: Application logger plugin, [FR](https://github.com/roadrunner-server/roadrunner/issues/1227) (thanks @wolfy-j)
  **Docs**: [PHP-lib](https://github.com/roadrunner-php/app-logger)
- ✏ **AMQP plugin**: new configuration options. [FR](https://github.com/roadrunner-server/roadrunner/issues/1351), (thanks @andrey-tech)
```yaml
jobs:
  pipelines:
    example:
      driver: amqp
      config:
        # Durable exchange
        #
        # Default: true
        exchange_durable: true

        # Auto-deleted exchange
        #
        # Default: false
        exchange_auto_deleted: false

        # Auto-deleted queue
        #
        # Default: false
        queue_auto_deleted: false
```

- ✏ **Workers pool (SDK)**: New option to control the `reset_timeout`. Note that the `pool.Reset` is protected by mutexes, meaning that if you have some requests already in the pool, you'll have to wait for these requests to be processed. The `reset_timeout` does not count this time.

```yaml
pool:
  allocate_timeout: 10s
  reset_timeout: 10s
  destroy_timeout: 10s
```

- ✏ **Centrifugo plugin**: New `centrifugo` plugin. Which is going to replace existing `broadcast` + `websockets` plugins. [FR](https://github.com/roadrunner-server/roadrunner/issues/1134).
  **Docs**: [PHP-lib](https://github.com/roadrunner-php/centrifugo)

RoadRunner config:

```yaml
version: "2.7"

centrifuge:
  # Centrifugo server proxy address (docs: https://centrifugal.dev/docs/server/proxy#grpc-proxy)
  #
  # Optional, default: tcp://127.0.0.1:30000
  proxy_address: "tcp://127.0.0.1:30000"

  # gRPC server API address (docs: https://centrifugal.dev/docs/server/server_api#grpc-api)
  #
  # Optional, default: tcp://127.0.0.1:30000. Centrifugo: `grpc_api` should be set to true and `grpc_port` should be the same as in the RR's config.
  grpc_api_address: tcp://127.0.0.1:30000

  # Use gRPC gzip compressor
  #
  # Optional, default: false
  use_compressor: true

  # Your application version
  #
  # Optional, default: v1.0.0
  version: "v1.0.0"

  # Your application name
  #
  # Optional, default: roadrunner
  name: "roadrunner"

  # TLS configuration
  #
  # Optional, default: null
  tls:
    # TLS key
    #
    # Required
    key: /path/to/key.pem

    # TLS certificate
    #
    # Required
    cert: /path/to/cert.pem


  # Workers pool settings. link: https://github.com/roadrunner-server/roadrunner/blob/master/.rr.yaml#L812
  #
  # Optional, default: null (see default values)
  pool: {}
```

## 🩹 Fixes:

- 🐛 **Headers middleware**: Header size is too small, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1336) (thanks @masterjus)
- 🐛 **gRPC plugin**: Protobuf compiler plugin segfaults on import statements, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1337) (thanks @phroggyy)
- 🐛 **Service plugin**: Get services list via RPC, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1339) (thanks @butschster)
- 🐛 **gRPC plugin**: Remote `protoc-gen-php-grpc` plugin error, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1341) (thanks @rapita)
- 🐛 **HTTP plugin**: Fail to upload files when RR's permissions are different from worker's, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1314) (thanks @egonbraun)


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
