### PR TITLE
chore: update deprecated `set-output`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,9 +5,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, beta, stable ]
+    branches: [ master, stable ]
   pull_request:
-    branches: [ master, beta, stable ]
+    branches: [ master, stable ]
   schedule:
     - cron: '0 15 * * 6'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Generate builder values
         id: values
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
-          echo "::set-output name=binary-name::rr`[ ${{ matrix.os }} = 'windows' ] && echo '.exe'`"
+          echo "version=$(echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//')" >> $GITHUB_OUTPUT
+          echo "timestamp=$(echo $(date +%FT%T%z))" >> $GITHUB_OUTPUT
+          echo "binary-name=$(echo $(echo rr`[ ${{ matrix.os }} = 'windows' ] && echo '.exe'`))" >> $GITHUB_OUTPUT
           if [ ${{ matrix.os }} == "windows" ]; then
-            echo "::set-output name=sign-cert-name::rr.exe.asc"
+            echo "sign-cert-name=rr.exe.asc" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sign-cert-name::rr.asc"
+            echo "sign-cert-name=rr.asc" >> $GITHUB_OUTPUT
           fi
 
       - name: Import GPG key
@@ -98,22 +98,22 @@ jobs:
       - name: Generate distributive directory name
         id: dist-dir
         run: >
-          echo "::set-output name=name::roadrunner-${{ steps.values.outputs.version }}-$(
+          echo "name=$(echo roadrunner-${{ steps.values.outputs.version }}-$(
             [ ${{ matrix.os }} != '' ] && echo '${{ matrix.os }}' || echo 'unknown'
           )$(
             [ ${{ matrix.compiler }} = 'musl-gcc' ] && echo '-musl'
-          )-${{ matrix.arch }}"
+          ))-${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
       - name: Generate distributive archive name
         id: dist-arch
         run: >
-          echo "::set-output name=name::${{ steps.dist-dir.outputs.name }}.$(
+          echo "name=$(echo ${{ steps.dist-dir.outputs.name }}.$(
             case ${{ matrix.archiver }} in
               zip) echo 'zip';;
               tar) echo 'tar.gz';;
               *)   exit 10;
             esac
-          )"
+          ))" >> $GITHUB_OUTPUT
 
       - name: Create distributive
         run: |
@@ -174,8 +174,8 @@ jobs:
       - name: Generate builder values
         id: values
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
+          echo "version=$(echo $(${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`)" >> $GITHUB_OUTPUT
+          echo "timestamp=$(echo $(date +%FT%T%z))" >> $GITHUB_OUTPUT
 
       - name: Build image
         uses: docker/build-push-action@v3 # Action page: <https://github.com/docker/build-push-action>

--- a/.github/workflows/release_dep.yml
+++ b/.github/workflows/release_dep.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Generate builder values
         id: values
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
-          echo "::set-output name=binary-name::rr"
-          echo "::set-output name=sign-cert-name::rr.asc"
+          echo "version=$(echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//')" >> $GITHUB_OUTPUT
+          echo "timestamp=$(echo $(date +%FT%T%z))" >> $GITHUB_OUTPUT
+          echo "binary-name=rr" >> $GITHUB_OUTPUT
+          echo "sign-cert-name=rr.asc" >> $GITHUB_OUTPUT
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5

--- a/.github/workflows/release_grpc.yml
+++ b/.github/workflows/release_grpc.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Generate builder values
         id: values
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//'`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
-          echo "::set-output name=binary-name::protoc-gen-php-grpc`[ ${{ matrix.os }} = 'windows' ] && echo '.exe'`"
+          echo "version=$(echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//')" >> $GITHUB_OUTPUT
+          echo "timestamp=$(echo $(date +%FT%T%z))" >> $GITHUB_OUTPUT
+          echo "binary-name=$(echo $(echo protoc-gen-php-grpc`[ ${{ matrix.os }} = 'windows' ] && echo '.exe'`))" >> $GITHUB_OUTPUT
           if [ ${{ matrix.os }} == "windows" ]; then
-            echo "::set-output name=sign-cert-name::protoc-gen-php-grpc.exe.asc"
+            echo "sign-cert-name=protoc-gen-php-grpc.exe.asc" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sign-cert-name::protoc-gen-php-grpc.asc"
+            echo "sign-cert-name=protoc-gen-php-grpc.asc" >> $GITHUB_OUTPUT
           fi
 
       - name: Import GPG key
@@ -96,22 +96,22 @@ jobs:
       - name: Generate distributive directory name
         id: dist-dir
         run: >
-          echo "::set-output name=name::protoc-gen-php-grpc-${{ steps.values.outputs.version }}-$(
+          echo "name=$(echo protoc-gen-php-grpc-${{ steps.values.outputs.version }}-$(
             [ ${{ matrix.os }} != '' ] && echo '${{ matrix.os }}' || echo 'unknown'
           )$(
             [ ${{ matrix.compiler }} = 'musl-gcc' ] && echo '-musl'
-          )-${{ matrix.arch }}"
+          ))-${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
       - name: Generate distributive archive name
         id: dist-arch
         run: >
-          echo "::set-output name=name::${{ steps.dist-dir.outputs.name }}.$(
+          echo "name=$(echo ${{ steps.dist-dir.outputs.name }}.$(
             case ${{ matrix.archiver }} in
               zip) echo 'zip';;
               tar) echo 'tar.gz';;
               *)   exit 10;
             esac
-          )"
+          ))" >> $GITHUB_OUTPUT
 
       - name: Create distributive
         run: |

--- a/.github/workflows/release_grpc_buf.yml
+++ b/.github/workflows/release_grpc_buf.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Generate builder values
         id: values
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/} | sed -e 's/*//'`"
+          echo "version=$(echo ${GITHUB_REF##*/} | sed -e 's/*//')" >> $GITHUB_OUTPUT
 
       - name: Build image
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Generate version value
         id: values # for PR this value will be `merge@__hash__`, SO: <https://stackoverflow.com/a/59780579/2252921>
         run: |
-          echo "::set-output name=version::`echo ${GITHUB_REF##*/}`@`echo ${GITHUB_SHA} | cut -c1-8`"
-          echo "::set-output name=timestamp::`date +%FT%T%z`"
+          echo "{name}={version} >> `echo ${GITHUB_REF##*/}`@`echo ${GITHUB_SHA} | cut -c1-8`"
+          echo "{name}={timestamp} >> `date +%FT%T%z`"
 
       - name: Compile binary file
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Generate version value
         id: values # for PR this value will be `merge@__hash__`, SO: <https://stackoverflow.com/a/59780579/2252921>
         run: |
-          echo "{name}={version} >> `echo ${GITHUB_REF##*/}`@`echo ${GITHUB_SHA} | cut -c1-8`"
-          echo "{name}={timestamp} >> `date +%FT%T%z`"
+          echo "version=$(echo ${GITHUB_REF##*/} | sed -e 's/^[vV ]*//')" >> $GITHUB_OUTPUT
+          echo "timestamp=$(echo $(date +%FT%T%z))" >> $GITHUB_OUTPUT
 
       - name: Compile binary file
         env:


### PR DESCRIPTION
# Reason for This PR

- Update deprecated GitHub actions: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Description of Changes

- Replace all `set-output` -> `>> $GITHUB_OUTPUT`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
