### PR TITLE
chore: fix the description of the `--silent` flag

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -122,7 +122,7 @@ func NewCommand(cmdName string) *cobra.Command { //nolint:funlen,gocognit
 	f.StringVarP(&workDir, "WorkDir", "w", "", "working directory")
 	f.StringVarP(&dotenv, "dotenv", "", "", fmt.Sprintf("dotenv file [$%s]", envDotenv))
 	f.BoolVarP(&debug, "debug", "d", false, "debug mode")
-	f.BoolVarP(silent, "silent", "s", false, "print startup message")
+	f.BoolVarP(silent, "silent", "s", false, "do not print startup message")
 	f.StringArrayVarP(override, "override", "o", nil, "override config value (dot.notation=value)")
 
 	cmd.AddCommand(


### PR DESCRIPTION
# Reason for This PR

`--silent` flag description is flipped.

## Description of Changes

`--silent` flag: `print startup message` → `do not print startup message`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
