### PR TITLE
feature: bash script to download the latest release

### DIFF
--- a/download-latest.sh
+++ b/download-latest.sh
@@ -62,7 +62,7 @@ get_os() {
   os_name=$(uname -s)
   case "$os_name" in
   'Darwin')
-    os='macos'
+    os='darwin'
     ;;
   'Linux')
     os='linux'

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -56,7 +56,7 @@ isAlpine() {
 get_os() {
   if isAlpine; then
     os="unknown-musl"
-    return 1
+    return 0
   fi
 
   os_name=$(uname -s)
@@ -103,7 +103,7 @@ get_archi() {
 get_compress() {
   if isAlpine; then
     compress="zip"
-    return 1
+    return 0
   fi
 
   os_name=$(uname -s)
@@ -181,9 +181,4 @@ download_binary() {
   printf "$GREEN%s\n$DEFAULT" "RoadRunner $latest archive successfully downloaded as $release_file"
 }
 
-# MAIN
-
-main() {
-  download_binary
-}
-main
+download_binary

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -92,11 +92,9 @@ get_archi() {
   'arm64')
     # macOS M1/M2
 
-    if [ $os = 'macos' ]; then
+    if [ $os = 'darwin' ]; then
       archi='arm64'
     fi
-
-    archi='arm64'
     ;;
   *)
     return 1

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+
+# This script can optionally use a GitHub token to increase your request limit (for example, if using this script in a CI).
+# To use a GitHub token, pass it through the GITHUB_PAT environment variable.
+
+# GLOBALS
+
+# Colors
+RED='\033[31m'
+GREEN='\033[32m'
+DEFAULT='\033[0m'
+
+# Project name
+PNAME='roadrunner'
+v='v'
+
+# GitHub API address
+GITHUB_API='https://api.github.com/repos/roadrunner-server/roadrunner/releases'
+# GitHub Release address
+GITHUB_REL='https://github.com/roadrunner-server/roadrunner/releases/download'
+
+# FUNCTIONS
+
+# Gets the version of the latest stable version of RoadRunner by setting the $latest variable.
+# Returns 0 in case of success, 1 otherwise.
+get_latest() {
+  # temp_file is needed because the grep would start before the download is over
+  temp_file=$(mktemp -q /tmp/$PNAME.XXXXXXXXX)
+  latest_release="$GITHUB_API/latest"
+
+  if [ $? -ne 0 ]; then
+    echo "$0: Can't create temp file."
+    fetch_release_failure_usage
+    exit 1
+  fi
+
+  if [ -z "$GITHUB_PAT" ]; then
+    curl -s "$latest_release" >"$temp_file" || return 1
+  else
+    curl -H "Authorization: token $GITHUB_PAT" -s "$latest_release" >"$temp_file" || return 1
+  fi
+
+  latest="$(cat "$temp_file" | grep '"tag_name":' | cut -d ':' -f2 | tr -d '"' | tr -d ',' | tr -d ' ')"
+  latest="${latest:1}"
+
+  rm -f "$temp_file"
+  return 0
+}
+
+isAlpine() {
+   return "$(cat "/etc/os-release" | grep "NAME=" | grep -ic "Alpine")"
+}
+
+# Gets the OS by setting the $os variable.
+# Returns 0 in case of success, 1 otherwise.
+get_os() {
+  if isAlpine; then
+    os="unknown-musl"
+    return 1
+  fi
+
+  os_name=$(uname -s)
+  case "$os_name" in
+  'Darwin')
+    os='macos'
+    ;;
+  'Linux')
+    os='linux'
+    ;;
+  'MINGW'*)
+    os='windows'
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+  return 0
+}
+
+
+# Gets the architecture by setting the $archi variable.
+# Returns 0 in case of success, 1 otherwise.
+get_archi() {
+  architecture=$(uname -m)
+
+  case "$architecture" in ('x86_64' | 'amd64')
+    archi='amd64';;'arm64')
+    # macOS M1/M2
+
+    if [ $os = 'macos' ]; then
+      archi='arm64'
+    fi
+
+    archi='arm64'
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+  return 0
+}
+
+get_compress() {
+  if isAlpine; then
+    compress="zip"
+    return 1
+  fi
+
+  os_name=$(uname -s)
+  case "$os_name" in
+  'Darwin')
+    compress='tar.gz'
+    ;;
+  'Linux')
+    compress='tar.gz'
+    ;;
+  'MINGW'*)
+    compress='zip'
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+  return 0
+}
+
+not_available_failure_usage() {
+  printf "$RED%s\n$DEFAULT" 'ERROR: RoadRunner binary is not available for your OS distribution or your architecture yet.'
+  echo ''
+  echo 'However, you can easily compile the binary from the source files.'
+  echo 'Follow the steps at the page ("Source" tab): TODO'
+}
+
+fetch_release_failure_usage() {
+  echo ''
+  printf "$RED%s\n$DEFAULT" 'ERROR: Impossible to get the latest stable version of RoadRunner.'
+  echo 'Please let us know about this issue: https://github.com/roadrunner-server/roadrunner/issues/new/choose'
+  echo ''
+  echo 'In the meantime, you can manually download the appropriate binary from the GitHub release assets here: https://github.com/roadrunner-server/roadrunner/releases/latest'
+}
+
+fill_release_variables() {
+  # Fill $latest variable.
+  if ! get_latest; then
+    fetch_release_failure_usage
+    exit 1
+  fi
+  if [ "$latest" = '' ]; then
+    fetch_release_failure_usage
+    exit 1
+  fi
+  # Fill $os variable.
+  if ! get_os; then
+    not_available_failure_usage
+    exit 1
+  fi
+  # Fill $archi variable.
+  if ! get_archi; then
+    not_available_failure_usage
+    exit 1
+  fi
+
+  # Fill $compress variable
+  if ! get_compress; then
+    not_available_failure_usage
+    exit 1
+  fi
+}
+
+download_binary() {
+  fill_release_variables
+  echo "Downloading RoadRunner binary $latest for $os, architecture $archi..."
+  release_file="$PNAME-$latest-$os-$archi.$compress"
+
+  curl --fail -OL "$GITHUB_REL/${v}$latest/$release_file"
+  if [ $? -ne 0 ]; then
+    fetch_release_failure_usage
+    exit 1
+  fi
+
+  printf "$GREEN%s\n$DEFAULT" "RoadRunner $latest archive successfully downloaded as $release_file"
+}
+
+# MAIN
+
+main() {
+  download_binary
+}
+main

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -12,7 +12,6 @@ DEFAULT='\033[0m'
 
 # Project name
 PNAME='roadrunner'
-v='v'
 
 # GitHub API address
 GITHUB_API='https://api.github.com/repos/roadrunner-server/roadrunner/releases'
@@ -40,8 +39,8 @@ get_latest() {
     curl -H "Authorization: token $GITHUB_PAT" -s "$latest_release" >"$temp_file" || return 1
   fi
 
-  latest="$(cat "$temp_file" | grep '"tag_name":' | cut -d ':' -f2 | tr -d '"' | tr -d ',' | tr -d ' ')"
-  latest="${latest:1}"
+  latest="$(cat "$temp_file" | grep '"tag_name":' | cut -d ':' -f2 | tr -d '"' | tr -d ',' | tr -d ' ' | tr -d 'v')"
+  latestV="$(cat "$temp_file" | grep '"tag_name":' | cut -d ':' -f2 | tr -d '"' | tr -d ',' | tr -d ' ')"
 
   rm -f "$temp_file"
   return 0
@@ -176,7 +175,7 @@ download_binary() {
   echo "Downloading RoadRunner binary $latest for $os, architecture $archi..."
   release_file="$PNAME-$latest-$os-$archi.$compress"
 
-  curl --fail -OL "$GITHUB_REL/${v}$latest/$release_file"
+  curl --fail -OL "$GITHUB_REL/$latestV/$release_file"
   if [ $? -ne 0 ]; then
     fetch_release_failure_usage
     exit 1

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -81,25 +81,28 @@ get_os() {
   return 0
 }
 
-# Gets the architecture by setting the $archi variable.
+# Gets the architecture by setting the $arch variable.
 # Returns 0 in case of success, 1 otherwise.
-get_archi() {
+get_arch() {
   architecture=$(uname -m)
 
-  case "$architecture" in 'x86_64' | 'amd64')
-    archi='amd64'
+  # case 1
+  case "$architecture" in
+  'x86_64' | 'amd64')
+    arch='amd64'
     ;;
-  'arm64')
-    # macOS M1/M2
 
-    if [ $os = 'darwin' ]; then
-      archi='arm64'
-    fi
+  # case 2
+  'arm64')
+    arch='arm64'
     ;;
+
+  # all other
   *)
     return 1
     ;;
   esac
+
   return 0
 }
 
@@ -155,8 +158,8 @@ fill_release_variables() {
     not_available_failure_usage
     exit 1
   fi
-  # Fill $archi variable.
-  if ! get_archi; then
+  # Fill $arch variable.
+  if ! get_arch; then
     not_available_failure_usage
     exit 1
   fi
@@ -170,8 +173,8 @@ fill_release_variables() {
 
 download_binary() {
   fill_release_variables
-  echo "Downloading RoadRunner binary $latest for $os, architecture $archi..."
-  release_file="$PNAME-$latest-$os-$archi.$compress"
+  echo "Downloading RoadRunner binary $latest for $os, architecture $arch..."
+  release_file="$PNAME-$latest-$os-$arch.$compress"
 
   curl --fail -OL "$GITHUB_REL/$latestV/$release_file"
   if [ $? -ne 0 ]; then

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -47,18 +47,19 @@ get_latest() {
   return 0
 }
 
+# 0 -> not alpine
+# >0 -> alpine
 isAlpine() {
-   return "$(cat "/etc/os-release" | grep "NAME=" | grep -ic "Alpine")"
+  if [ "$(cat "/etc/os-release" | grep "NAME=" | grep -ic "Alpine")" ]; then
+    return 1
+  fi
+
+  return 0
 }
 
 # Gets the OS by setting the $os variable.
 # Returns 0 in case of success, 1 otherwise.
 get_os() {
-  if isAlpine; then
-    os="unknown-musl"
-    return 0
-  fi
-
   os_name=$(uname -s)
   case "$os_name" in
   'Darwin')
@@ -66,6 +67,10 @@ get_os() {
     ;;
   'Linux')
     os='linux'
+    if isAlpine; then
+      os="unknown-musl"
+    fi
+
     ;;
   'MINGW'*)
     os='windows'
@@ -77,14 +82,15 @@ get_os() {
   return 0
 }
 
-
 # Gets the architecture by setting the $archi variable.
 # Returns 0 in case of success, 1 otherwise.
 get_archi() {
   architecture=$(uname -m)
 
-  case "$architecture" in ('x86_64' | 'amd64')
-    archi='amd64';;'arm64')
+  case "$architecture" in 'x86_64' | 'amd64')
+    archi='amd64'
+    ;;
+  'arm64')
     # macOS M1/M2
 
     if [ $os = 'macos' ]; then
@@ -101,11 +107,6 @@ get_archi() {
 }
 
 get_compress() {
-  if isAlpine; then
-    compress="zip"
-    return 0
-  fi
-
   os_name=$(uname -s)
   case "$os_name" in
   'Darwin')
@@ -113,6 +114,9 @@ get_compress() {
     ;;
   'Linux')
     compress='tar.gz'
+    if isAlpine; then
+      compress="zip"
+    fi
     ;;
   'MINGW'*)
     compress='zip'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/buger/goterm v1.0.4
-	github.com/dustin/go-humanize v1.0.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/joho/godotenv v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5
@@ -195,7 +195,7 @@ require (
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.5.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/genproto v0.0.0-20230113154510-dbe35b8444a5 // indirect
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/twmb/murmur3 v1.1.6 // indirect
-	github.com/uber-go/tally/v4 v4.1.4 // indirect
+	github.com/uber-go/tally/v4 v4.1.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.44.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -441,7 +441,6 @@ github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+M
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -466,8 +465,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
-github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
@@ -631,7 +628,6 @@ github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
@@ -928,8 +924,8 @@ github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber-go/tally/v4 v4.1.1/go.mod h1:aXeSTDMl4tNosyf6rdU8jlgScHyjEGGtfJ/uwCIf/vM=
-github.com/uber-go/tally/v4 v4.1.4 h1:LzQyYvWQIp1gYNWU2tDNzVl04H2VchEUvMgabx/7MTI=
-github.com/uber-go/tally/v4 v4.1.4/go.mod h1:aXeSTDMl4tNosyf6rdU8jlgScHyjEGGtfJ/uwCIf/vM=
+github.com/uber-go/tally/v4 v4.1.5 h1:PlOR9dUoE1GV/xAk+coMnoxrR+j6Fz5qjKb49TUjBf8=
+github.com/uber-go/tally/v4 v4.1.5/go.mod h1:aXeSTDMl4tNosyf6rdU8jlgScHyjEGGtfJ/uwCIf/vM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.44.0 h1:R+gLUhldIsfg1HokMuQjdQ5bh9nuXHPIfvkYUu9eR5Q=
@@ -1522,8 +1518,6 @@ google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029/go.mod h1:rZS5c/ZV
 google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230113154510-dbe35b8444a5 h1:wJT65XLOzhpSPCdAmmKfz94SlmnQzDzjm3Cj9k3fsXY=
 google.golang.org/genproto v0.0.0-20230113154510-dbe35b8444a5/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,7 @@ github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+M
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -467,6 +468,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9ndfrgrXUbOGObLHKBR4Fl3nZXwM2c7OYTT8hM=
@@ -628,6 +631,7 @@ github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
@@ -1520,6 +1524,8 @@ google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZV
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230113154510-dbe35b8444a5 h1:wJT65XLOzhpSPCdAmmKfz94SlmnQzDzjm3Cj9k3fsXY=
+google.golang.org/genproto v0.0.0-20230113154510-dbe35b8444a5/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=


### PR DESCRIPTION
# Reason for This PR

- Provide a way to download RR via the bash script.
- Supported OS:
1. Windows (MINGW, WLS2)
2. Linux (+Alpine)
3. macOS (Darwin)

## Description of Changes

- Create `download-latest.sh` bash.
- Usage: `curl --proto '=https' --tlsv1.2 -sSf  https://raw.githubusercontent.com/roadrunner-server/roadrunner/feature/bash-script/download-latest.sh | sh`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
