### PR TITLE
chore(bc): update `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,24 +3,31 @@
     "type": "metapackage",
     "description": "RoadRunner: High-performance PHP application server and process manager written in Go and powered with plugins",
     "license": "MIT",
+    "homepage": "https://roadrunner.dev/",
+    "support": {
+        "docs": "https://roadrunner.dev/docs",
+        "issues": "https://github.com/roadrunner-server/roadrunner/issues",
+        "forum": "https://forum.roadrunner.dev/",
+        "chat": "https://discord.gg/V6EK4he"
+    },
     "authors": [
         {
             "name": "Anton Titov / Wolfy-J",
             "email": "wolfy.jd@gmail.com"
         },
         {
+            "name": "Valery Piashchynski",
+            "homepage": "https://github.com/rustatian"
+        },
+        {
             "name": "RoadRunner Community",
             "homepage": "https://github.com/roadrunner-server/roadrunner/graphs/contributors"
         }
     ],
-    "require": {
-        "spiral/roadrunner-worker": "^2.0",
-        "spiral/roadrunner-cli": "^2.0",
-        "spiral/roadrunner-http": "^2.0"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/roadrunner-server"
+        }
+    ]
 }


### PR DESCRIPTION
# Reason for This PR

The `spiral/roadrunner` is a [metapackage](https://getcomposer.org/doc/04-schema.md#type).  
Historically we have a couple of incorrect dependencies in the metapackage. And that blocks us from making a new true dependency graph.

Look at this:

![{FB8EE563-B7B2-4D1E-86AB-41C368F52C06}](https://user-images.githubusercontent.com/4152481/213657004-bc8a9db6-8988-47ae-ab27-470f7b537d59.png)

- `spiral/roadrunner (rr-server/rr)` mustn't depend on `spiral/roadrunner-http` because it should be inverted.
- the same about the `roadrunner/worker`
- `spiral/roadrunner (rr-server/rr)` mustn't depend on `roadrunner/cli` because a cyclic dependency would be created if
  the other deps could be fixed (`rr-cli -> rr-worker -> rr-server -> rr-cli`)

We couldn't remove then before because it means a breaking change: some packages that use the metapackage as a dependency [rely on cross-dependencies](https://github.com/laravel/octane/blob/f39188719b47a20593ed935e9589a2b36f2f4d91/bin/roadrunner-worker#L14-L15).

> **Warning**: the PR has breaking changes and should be merged only in the next major release.

## Description of Changes

Removed blocks:
- `require` - we don't need to pull hard these `spiral/roadrunner-*` packages with the metapackage **[BC]**.

Updated blocks:
- `authors`: added [Valery Piashchynski](https://github.com/rustatian).

Added blocks:
- `homepage`
- `support`
- `funding`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] `composer validate` passed
