### PR TITLE
pre-release: `v2023.1.0-rc.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # CHANGELOG
 
+## <center> 🚀 v2023.1.0-rc.2 🚀 </center>
+
+## <center>👀 New: </center>
+
+- ✒️ **Velox:** Support for `v2023` and `v4` plugins. v2` and `v3` plugins are still supported.
+
+### <center>🩹 Fixes:</center>
+
+- 🐛 **Service plugin**: Fix deadlock on channel send operation when using `remain_after_exit`.
+- 🐛 **Service plugin**: Send `SIGINT` instead of `SIGKILL` to underlying processes with `5s` timeout to let the process exit gracefully.
+- 🐛 **Config plugin**: Fix missing default env variable syntax parser, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1522), (thanks @benalf)
+
+---
+
 ## <center> 🚀 v2023.1.0-rc.1 🚀 </center>
 
-## <center>👀 New: <center
+## <center>👀 New: </center>
+
 - ✒️ **Server plugin:** pass `RR_VERSION` env variable to the worker to check the current RR version. Version passed without the `v` prefix (e.g. `2023.1.0`).
 - ✒️ **Lock plugin:** faster first call to acquire the lock.
 
@@ -10,7 +25,7 @@
 
 ## <center> 🚀 v2023.1.0-beta.1 🚀 </center>
 
-## <center>👀 New: <center>
+## <center>👀 New: </center>
 
 - ✒️ **Kafka plugin:** Totally reworked Kafka plugin. Now it supports regexps for the topics, marked commits for the group consumers, and SASL authentication. Configuration reference: [link](https://roadrunner.dev/docs/plugins-jobs/2.x/en#kafka-driver).
 - ✒️ **RPC plugin:** RPC plugin would be available immediately before the worker initialization. That means, that PHP worker may use all RPC methods immediately.

--- a/go.sum
+++ b/go.sum
@@ -1017,8 +1017,6 @@ github.com/roadrunner-server/send/v4 v4.0.6 h1:BXkMZx5FIpDdU6H7UH0NNBgo2jR3zJDzf
 github.com/roadrunner-server/send/v4 v4.0.6/go.mod h1:cKhKMryDTNhc0FsDtTIN/OJzL+YfG7wao2gcIcE8bcw=
 github.com/roadrunner-server/server/v4 v4.1.2 h1:mx42NqN5T4CqIKs8l9pedSfxGP64xH1dCC4O+JUInWc=
 github.com/roadrunner-server/server/v4 v4.1.2/go.mod h1:2Ngf1IgVwIMNPV/+6rHQ23apI+77Mzab2CKULxCRv+I=
-github.com/roadrunner-server/service/v4 v4.1.1 h1:pQrKq2rwXOhnFKkv8i0CdiInXppu+f6F4DvRk0h55xQ=
-github.com/roadrunner-server/service/v4 v4.1.1/go.mod h1:EM4QbYvE9gwXH2Q1fo3/q5nTp0K4mIosLfOW39/5gso=
 github.com/roadrunner-server/service/v4 v4.1.2 h1:hPkHbVxh/HiAx9luzuRoesCwD/uvBW2hK2PykcLW5ZA=
 github.com/roadrunner-server/service/v4 v4.1.2/go.mod h1:EM4QbYvE9gwXH2Q1fo3/q5nTp0K4mIosLfOW39/5gso=
 github.com/roadrunner-server/sqs/v4 v4.2.4 h1:zs/S4ByTq+LsqtdMBusTj/hlWn+JEVjlVv3ucukUh/Y=


### PR DESCRIPTION
# Reason for This PR

- pre-release: `v2023.1.0-rc.2`
- tests: https://github.com/roadrunner-server/rr-e2e-tests/releases/tag/v2023.1.0-rc.2

## Description of Changes

## <center> 🚀 v2023.1.0-rc.2 🚀 </center>

## <center>👀 New: </center>

- ✒️ **Velox:** Support for `v2023` and `v4` plugins. `v2` and `v3` plugins are still supported.

### <center>🩹 Fixes:</center>

- 🐛 **Service plugin**: Fix deadlock on channel send operation when using `remain_after_exit`.
- 🐛 **Service plugin**: Send `SIGINT` instead of `SIGKILL` to underlying processes with `5s` timeout to let the process exit gracefully.
- 🐛 **Config plugin**: Fix missing default env variable syntax parser, [BUG](https://github.com/roadrunner-server/roadrunner/issues/1522), (thanks @benalf)


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
