### PR TITLE
feature: flag to enable/disable experimental features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/roadrunner-server/beanstalk/v4 v4.5.9
 	github.com/roadrunner-server/boltdb/v4 v4.7.6
 	github.com/roadrunner-server/centrifuge/v4 v4.5.3
-	github.com/roadrunner-server/config/v4 v4.4.9
+	github.com/roadrunner-server/config/v4 v4.5.0
 	github.com/roadrunner-server/endure/v2 v2.4.3
 	github.com/roadrunner-server/errors v1.3.0
 	github.com/roadrunner-server/fileserver/v4 v4.1.8

--- a/go.sum
+++ b/go.sum
@@ -1241,8 +1241,8 @@ github.com/roadrunner-server/boltdb/v4 v4.7.6 h1:vRWB03XgcKFDMEn/7h5puOE0MCKD0ZX
 github.com/roadrunner-server/boltdb/v4 v4.7.6/go.mod h1:rgzPNyMxGnOzANSQkyfY+IGBLCaYAjd3+rwlsmmqJ7A=
 github.com/roadrunner-server/centrifuge/v4 v4.5.3 h1:jFAiV+sHBiAsca+aIbxjI7lMIRmyXtPHMV64ibggcMA=
 github.com/roadrunner-server/centrifuge/v4 v4.5.3/go.mod h1:1+qRJAlB0fUAXFMfjzu9a9aGsGoP+m+YHI3CGYM2Ua0=
-github.com/roadrunner-server/config/v4 v4.4.9 h1:RkYs6Fd3Lo5ZdHOm8RTsX7jlySyDpXyZzt0rp7hw38A=
-github.com/roadrunner-server/config/v4 v4.4.9/go.mod h1:3GZTCaZXUEcLTILoauurn0tMgnu0/58RV9k+Zewmsz0=
+github.com/roadrunner-server/config/v4 v4.5.0 h1:2XWeu9XZ0eeenCpQEPHRJ+whD/FnayazBEIsSJj3pbo=
+github.com/roadrunner-server/config/v4 v4.5.0/go.mod h1:3GZTCaZXUEcLTILoauurn0tMgnu0/58RV9k+Zewmsz0=
 github.com/roadrunner-server/endure/v2 v2.4.3 h1:R9DdsLiLjtSFivZ1HKk/1eDZ0TYaKHQzakVwz9D2hto=
 github.com/roadrunner-server/endure/v2 v2.4.3/go.mod h1:4n3PdwZ3h/IRL2enDGvEVXtaQgqRnZ74VOyZtOJq528=
 github.com/roadrunner-server/errors v1.3.0 h1:kLVXpXne0jMReN7pj8KIhyYyjqKjsPC5DRGqMsd4/Fo=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -42,6 +42,8 @@ func NewCommand(cmdName string) *cobra.Command { //nolint:funlen,gocognit
 	override := &[]string{}
 	// do not print startup message
 	silent := toPtr(false)
+	// enable experimental features
+	experimental := toPtr(false)
 
 	// working directory
 	var workDir string
@@ -146,6 +148,7 @@ func NewCommand(cmdName string) *cobra.Command { //nolint:funlen,gocognit
 
 	f := cmd.PersistentFlags()
 
+	f.BoolVarP(experimental, "enable-experimental", "e", false, "enable experimental features")
 	f.BoolVarP(forceStop, "force", "f", false, "force stop")
 	f.BoolVarP(pidFile, "pid", "p", false, "create a .pid file")
 	f.StringVarP(cfgFile, "config", "c", ".rr.yaml", "config file")
@@ -158,7 +161,7 @@ func NewCommand(cmdName string) *cobra.Command { //nolint:funlen,gocognit
 	cmd.AddCommand(
 		workers.NewCommand(cfgFile, override),
 		reset.NewCommand(cfgFile, override, silent),
-		serve.NewCommand(override, cfgFile, silent),
+		serve.NewCommand(override, cfgFile, silent, experimental),
 		stop.NewCommand(silent, forceStop),
 		jobs.NewCommand(cfgFile, override, silent),
 	)

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -21,7 +21,7 @@ const (
 )
 
 // NewCommand creates `serve` command.
-func NewCommand(override *[]string, cfgFile *string, silent *bool) *cobra.Command { //nolint:funlen
+func NewCommand(override *[]string, cfgFile *string, silent *bool, experimental *bool) *cobra.Command { //nolint:funlen
 	return &cobra.Command{
 		Use:   "serve",
 		Short: "Start RoadRunner server",
@@ -39,11 +39,12 @@ func NewCommand(override *[]string, cfgFile *string, silent *bool) *cobra.Comman
 			}
 
 			cfg := &configImpl.Plugin{
-				Path:    *cfgFile,
-				Prefix:  rrPrefix,
-				Timeout: containerCfg.GracePeriod,
-				Flags:   *override,
-				Version: meta.Version(),
+				Path:                 *cfgFile,
+				Prefix:               rrPrefix,
+				Timeout:              containerCfg.GracePeriod,
+				Flags:                *override,
+				Version:              meta.Version(),
+				ExperimentalFeatures: *experimental,
 			}
 
 			endureOptions := []endure.Options{
@@ -58,7 +59,7 @@ func NewCommand(override *[]string, cfgFile *string, silent *bool) *cobra.Comman
 			ll, err := container.ParseLogLevel(containerCfg.LogLevel)
 			if err != nil {
 				if !*silent {
-					fmt.Printf("[WARN] Failed to parse log level, using default (error): %s\n", err)
+					fmt.Println(fmt.Errorf("[WARN] Failed to parse log level, using default (error): %w", err))
 				}
 			}
 			cont := endure.New(ll, endureOptions...)

--- a/internal/cli/serve/command_test.go
+++ b/internal/cli/serve/command_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestCommandProperties(t *testing.T) {
 	path := ""
-	cmd := serve.NewCommand(nil, &path, nil)
+	cmd := serve.NewCommand(nil, &path, nil, nil)
 
 	assert.Equal(t, "serve", cmd.Use)
 	assert.NotNil(t, cmd.RunE)
 }
 
 func TestCommandNil(t *testing.T) {
-	cmd := serve.NewCommand(nil, nil, nil)
+	cmd := serve.NewCommand(nil, nil, nil, nil)
 
 	assert.Equal(t, "serve", cmd.Use)
 	assert.NotNil(t, cmd.RunE)


### PR DESCRIPTION
# Reason for This PR

- Ability to provide some experimental features (like http3 or new destroy mechanism for the JOBS plugin and drivers)

## Description of Changes

- Add the experimental features flag:
  - `-e`: short form.
  - `--enable-experimental`: long form.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Added an `--enable-experimental` flag to enable experimental features. This new option allows users to test out upcoming features that are still in the experimental phase. Please note that these features may not be fully stable or complete. Use this flag with caution and at your own risk.
- Test: Updated tests to accommodate the new `--enable-experimental` flag. These changes ensure that our testing suite remains accurate and reliable as we introduce new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->