### PR TITLE
Fixed composer installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Configuration located in the `.rr.yaml` file ([full sample](https://github.com/r
 You can also install RoadRunner automatically using the command shipped with the composer package, run:
 
 ```bash
-composer require spiral/roadrunner-http spiral/roadrunner-worker nyholm/psr7
+composer require spiral/roadrunner-cli
 ./vendor/bin/rr get-binary
 ```
 


### PR DESCRIPTION
# Reason for This PR

Docs of installation via composer are incorrect and don't even work (maybe just deprecated)

## Description of Changes

Changed from `composer require spiral/roadrunner-http spiral/roadrunner-worker nyholm/psr7` to `composer require spiral/roadrunner-cli` as noted at https://docs.roadrunner.dev/general/install

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the composer require command in the README to simplify package installation by including `roadrunner-cli`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->