### PR TITLE
feature: show RPC error message in terminal instead of failing

### DIFF
--- a/internal/cli/workers/render.go
+++ b/internal/cli/workers/render.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
-	"github.com/roadrunner-server/api/v4/plugins/v1/jobs"
+	"github.com/roadrunner-server/api/v4/plugins/v4/jobs"
 	"github.com/roadrunner-server/pool/state/process"
 )
 
@@ -19,11 +19,7 @@ const (
 )
 
 // WorkerTable renders table with information about rr server workers.
-func WorkerTable(writer io.Writer, workers []*process.State) *tablewriter.Table {
-	sort.Slice(workers, func(i, j int) bool {
-		return workers[i].Pid < workers[j].Pid
-	})
-
+func WorkerTable(writer io.Writer, workers []*process.State, err error) *tablewriter.Table {
 	tw := tablewriter.NewWriter(writer)
 	tw.SetHeader([]string{"PID", "Status", "Execs", "Memory", "CPU%", "Created"})
 	tw.SetColMinWidth(0, 7)
@@ -32,6 +28,23 @@ func WorkerTable(writer io.Writer, workers []*process.State) *tablewriter.Table 
 	tw.SetColMinWidth(3, 7)
 	tw.SetColMinWidth(4, 7)
 	tw.SetColMinWidth(5, 18)
+
+	if err != nil {
+		tw.Append([]string{
+			"0",
+			err.Error(),
+			"ERROR",
+			"ERROR",
+			"ERROR",
+			"ERROR",
+		})
+
+		return tw
+	}
+
+	sort.Slice(workers, func(i, j int) bool {
+		return workers[i].Pid < workers[j].Pid
+	})
 
 	for i := 0; i < len(workers); i++ {
 		tw.Append([]string{
@@ -75,11 +88,7 @@ func ServiceWorkerTable(writer io.Writer, workers []*process.State) *tablewriter
 }
 
 // JobsTable renders table with information about rr server jobs.
-func JobsTable(writer io.Writer, jobs []*jobs.State) *tablewriter.Table {
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].Pipeline < jobs[j].Pipeline
-	})
-
+func JobsTable(writer io.Writer, jobs []*jobs.State, err error) *tablewriter.Table {
 	tw := tablewriter.NewWriter(writer)
 	tw.SetAutoWrapText(false)
 	tw.SetHeader([]string{"Status", "Pipeline", "Driver", "Queue", "Active", "Delayed", "Reserved"})
@@ -91,6 +100,24 @@ func JobsTable(writer io.Writer, jobs []*jobs.State) *tablewriter.Table {
 	tw.SetColWidth(10)
 	tw.SetColWidth(10)
 	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+
+	if err != nil {
+		tw.Append([]string{
+			err.Error(),
+			"ERROR",
+			"ERROR",
+			"ERROR",
+			"ERROR",
+			"ERROR",
+			"ERROR",
+		})
+
+		return tw
+	}
+
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].Pipeline < jobs[j].Pipeline
+	})
 
 	for i := 0; i < len(jobs); i++ {
 		tw.Append([]string{


### PR DESCRIPTION
# Reason for This PR

ref: #1952 

## Description of Changes

- Instead of failing, show an error message per-plugin in the workers table. This will not affect information which other plugins can show.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in worker and job processing, ensuring that errors are now printed and handled more gracefully.

- **Improvements**
  - Updated sorting of worker and job data for better organization and readability.
  - Enhanced table rendering for workers and jobs, including error handling, to provide more reliable output.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->