### PR TITLE
feature: Introducing RoadRunner Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 	<a href="https://discord.gg/TFeEmCs"><img src="https://img.shields.io/badge/discord-chat-magenta.svg"></a>
 	<a href="https://packagist.org/packages/spiral/roadrunner"><img src="https://img.shields.io/packagist/dd/spiral/roadrunner?style=flat-square"></a>
     <img alt="All releases" src="https://img.shields.io/github/downloads/roadrunner-server/roadrunner/total">
+  <a href="https://gurubase.io/g/roadrunner"><img src="https://img.shields.io/badge/Gurubase-Ask%20RoadRunner%20Guru-006BFF?style=flat-square"></a>
 </p>
 
 RoadRunner is an open-source (MIT licensed) high-performance PHP application server, process manager written in Go and powered with plugins ❤️.
@@ -42,7 +43,8 @@ It supports running as a service with the ability to extend its functionality on
 	<a href="https://roadrunner.dev/"><b>Official Website</b></a> |
 	<a href="https://docs.roadrunner.dev/"><b>Documentation</b></a> |
     <a href="https://github.com/orgs/roadrunner-server/discussions"><b>Forum</b></a> |
-    <a href="https://github.com/orgs/roadrunner-server/projects/4"><b>Release schedule</b></a>
+    <a href="https://github.com/orgs/roadrunner-server/projects/4"><b>Release schedule</b></a> |
+    <a href="https://gurubase.io/g/roadrunner"><b>Ask RoadRunner Guru</b></a>
 </p>
 
 # Installation


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [RoadRunner Guru](https://gurubase.io/g/roadrunner) to Gurubase. RoadRunner Guru uses the data from this repo and data from the [docs](https://docs.roadrunner.dev/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "RoadRunner Guru", which highlights that RoadRunner now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable RoadRunner Guru in Gurubase, just let me know that's totally fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a badge linking to Gurubase for enhanced resource visibility.
	- Introduced a new link to "Ask RoadRunner Guru" in the footer for additional support.

- **Documentation**
	- Updated the README.md to improve user engagement and support resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->