### PR TITLE
return cfg, add expirement parameter

### DIFF
--- a/lib/roadrunner.go
+++ b/lib/roadrunner.go
@@ -17,10 +17,11 @@ type RR struct {
 	container *endure.Endure
 	stop      chan struct{}
 	Version   string
+	cfg       *configImpl.Plugin
 }
 
 // NewRR creates a new RR instance that can then be started or stopped by the caller
-func NewRR(cfgFile string, override []string, pluginList []any) (*RR, error) {
+func NewRR(cfgFile string, override []string, pluginList []any, withExperimentalFeatures bool) (*RR, error) {
 	// create endure container config
 	containerCfg, err := container.NewConfig(cfgFile)
 	if err != nil {
@@ -28,10 +29,11 @@ func NewRR(cfgFile string, override []string, pluginList []any) (*RR, error) {
 	}
 
 	cfg := &configImpl.Plugin{
-		Path:    cfgFile,
-		Timeout: containerCfg.GracePeriod,
-		Flags:   override,
-		Version: getRRVersion(),
+		Path:                 cfgFile,
+		Timeout:              containerCfg.GracePeriod,
+		Flags:                override,
+		Version:              getRRVersion(),
+		ExperimentalFeatures: withExperimentalFeatures,
 	}
 
 	// create endure container
@@ -66,6 +68,7 @@ func NewRR(cfgFile string, override []string, pluginList []any) (*RR, error) {
 		container: endureContainer,
 		stop:      make(chan struct{}, 1),
 		Version:   cfg.Version,
+		cfg:       cfg,
 	}, nil
 }
 
@@ -115,4 +118,8 @@ func getRRVersion() string {
 	}
 
 	return ""
+}
+
+func (rr *RR) Config() *configImpl.Plugin {
+	return rr.cfg
 }


### PR DESCRIPTION
# Reason for This PR

want more control when you embed roadrunner

## Description of Changes

The main hope is to read the configured data from the roadrunner in order to better integrate with other businesses

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration field in the RR struct to enhance functionality.
	- Added a method to access configuration details within the RR instance.
	- Updated the constructor to support experimental features for advanced users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->