### PR TITLE
Update go to 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image page: <https://hub.docker.com/_/golang>
-FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.24-alpine as builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.24.2-alpine as builder
 
 # app version and build date must be passed during image building (version without any prefix).
 # e.g.: `docker build --build-arg "APP_VERSION=1.2.3" --build-arg "BUILD_TIME=$(date +%FT%T%z)" .`
@@ -12,8 +12,8 @@ WORKDIR /src
 
 # arguments to pass on each go tool link invocation
 ENV LDFLAGS="-s \
--X github.com/roadrunner-server/roadrunner/v2024/internal/meta.version=$APP_VERSION \
--X github.com/roadrunner-server/roadrunner/v2024/internal/meta.buildTime=$BUILD_TIME"
+    -X github.com/roadrunner-server/roadrunner/v2024/internal/meta.version=$APP_VERSION \
+    -X github.com/roadrunner-server/roadrunner/v2024/internal/meta.buildTime=$BUILD_TIME"
 
 # compile binary file
 RUN set -x

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/roadrunner-server/roadrunner/v2024
 
-go 1.24
-
-toolchain go1.24.0
+go 1.24.2
 
 require (
 	github.com/buger/goterm v1.0.4


### PR DESCRIPTION
# Reason for This PR

To resolve CVE-2025-22871 mentioned in https://github.com/roadrunner-server/roadrunner/issues/2166

## Description of Changes

Updates `go` to `1.24.2`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go language version specification for improved compatibility and consistency.
  - Refined the build environment setup to enhance build accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->