### PR TITLE
feat: bundle the rate limiter HTTP middleware

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -626,10 +626,43 @@ http:
   # Optional, default: false
   raw_body: false
 
-  # Middlewares for the http plugin, order is important. Allowed values is: "headers", "gzip", "static", "sendfile",  [SINCE 2.6] -> "new_relic", [SINCE 2.6] -> "http_metrics", [SINCE 2.7] -> "cache"
+  # Select HTTP middleware. Requests pass through this list from left to right.
   #
   # Default value: []
   middleware: [ "headers", "gzip" ]
+
+  # One rate-limit policy per RoadRunner process. Add "rate_limiter" to http.middleware to apply it.
+  # Place "proxy_ip_parser" before "rate_limiter" to use forwarded client IPs.
+  rate_limiter:
+    # Key mode: global (all requests), ip (client IP), or header (header value).
+    #
+    # Default: ip
+    key: ip
+
+    # HTTP header name. Required for key: header. Must be empty for other modes.
+    #
+    # Default: ""
+    header: ""
+
+    # Requests per interval. Must be a positive integer.
+    #
+    # Required.
+    rate: 60
+
+    # Interval for the request rate. Must be a positive duration.
+    #
+    # Default: 1s
+    interval: 1m
+
+    # Maximum requests allowed at once per key. Must be a positive integer.
+    #
+    # Default: 1
+    burst: 10
+
+    # Maximum stored keys per process. Must be a positive integer.
+    #
+    # Default: 10000
+    max_entries: 10000
 
   # Allow incoming requests only from the following subnets (https://en.wikipedia.org/wiki/Reserved_IP_addresses).
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # CHANGELOG
 
 releases: [docs](https://docs.roadrunner.dev/docs/releases)
+
+## Unreleased
+
+- Add the bundled `rate_limiter` HTTP middleware with global, IP, and header keys.

--- a/container/plugins.go
+++ b/container/plugins.go
@@ -26,6 +26,7 @@ import (
 	rrOtel "github.com/roadrunner-server/otel/v6"
 	"github.com/roadrunner-server/prometheus/v6"
 	proxyIP "github.com/roadrunner-server/proxy_ip_parser/v6"
+	ratelimiter "github.com/roadrunner-server/rate-limiter/v6"
 	"github.com/roadrunner-server/redis/v6"
 	"github.com/roadrunner-server/resetter/v6"
 	rpcPlugin "github.com/roadrunner-server/rpc/v6"
@@ -83,6 +84,7 @@ func Plugins() []any { //nolint:funlen
 		&prometheus.Plugin{},
 		&send.Plugin{},
 		&proxyIP.Plugin{},
+		&ratelimiter.Plugin{},
 		&rrOtel.Plugin{},
 		&fileserver.Plugin{},
 		// ===================

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/roadrunner-server/pool/v2 v2.0.0-beta.1
 	github.com/roadrunner-server/prometheus/v6 v6.0.0-beta.3
 	github.com/roadrunner-server/proxy_ip_parser/v6 v6.0.0-beta.4
+	github.com/roadrunner-server/rate-limiter/v6 v6.0.0-beta.1
 	github.com/roadrunner-server/redis/v6 v6.0.0-beta.5
 	github.com/roadrunner-server/resetter/v6 v6.0.0-beta.6
 	github.com/roadrunner-server/rpc/v6 v6.0.0-beta.6

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/roadrunner-server/prometheus/v6 v6.0.0-beta.3 h1:65ynsA6ZFPoMyR6I+oSU
 github.com/roadrunner-server/prometheus/v6 v6.0.0-beta.3/go.mod h1:HCI+0AOAX/vfu8TLPNDTQj4eyySQrDpsrSDmtGuQC60=
 github.com/roadrunner-server/proxy_ip_parser/v6 v6.0.0-beta.4 h1:C0affQFhSOtRa7VwNrYJ/wRl0C70B2X7Q7npdwJVlsk=
 github.com/roadrunner-server/proxy_ip_parser/v6 v6.0.0-beta.4/go.mod h1:mentPPiG4/bPq3u+AajQ/k6V2A0dQC8q5R5pbBX5rJg=
+github.com/roadrunner-server/rate-limiter/v6 v6.0.0-beta.1 h1:uV5t81icrW3yNf+XHoWKS/4bLjtNfqIpyp97e9EPe6w=
+github.com/roadrunner-server/rate-limiter/v6 v6.0.0-beta.1/go.mod h1:0avHut1xoSkjJGlAssxAD1xByzNUv0cWcALM8VdzKXg=
 github.com/roadrunner-server/redis/v6 v6.0.0-beta.5 h1:N7LCyiHzkgBCA+fbJlM8HkBtBQfbCRVPxhVdiSqpM7Y=
 github.com/roadrunner-server/redis/v6 v6.0.0-beta.5/go.mod h1:ZdZNb2efT8f9pTsvHvkwJg4bbghXYkegVODZG+6gEZc=
 github.com/roadrunner-server/resetter/v6 v6.0.0-beta.6 h1:+GSGvSNjsSMvE3AhDj9qQhUSA9+SGaFFDTihO/oko8g=

--- a/schemas/config/3.0.schema.json
+++ b/schemas/config/3.0.schema.json
@@ -627,8 +627,93 @@
               "http_metrics",
               "cache",
               "proxy_ip_parser",
-              "otel"
+              "otel",
+              "rate_limiter"
             ]
+          }
+        },
+        "rate_limiter": {
+          "description": "One rate-limit policy per RoadRunner process. Add rate_limiter to http.middleware to apply it.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rate"
+          ],
+          "properties": {
+            "key": {
+              "description": "Key mode: global for all requests, ip for the client IP, or header for a header value.",
+              "type": "string",
+              "enum": [
+                "global",
+                "ip",
+                "header"
+              ],
+              "default": "ip"
+            },
+            "header": {
+              "description": "HTTP header name. Required when key is header. Must be empty for other modes.",
+              "type": "string",
+              "default": ""
+            },
+            "rate": {
+              "description": "Requests per interval. Must be a positive integer.",
+              "type": "integer",
+              "minimum": 1
+            },
+            "interval": {
+              "description": "Interval for the request rate. Must be a positive duration.",
+              "type": "string",
+              "allOf": [
+                {
+                  "$ref": "https://raw.githubusercontent.com/roadrunner-server/roadrunner/refs/heads/master/schemas/config/3.0.schema.json#/definitions/Duration"
+                }
+              ],
+              "pattern": "[1-9]",
+              "default": "1s"
+            },
+            "burst": {
+              "description": "Maximum requests allowed at once per key.",
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "max_entries": {
+              "description": "Maximum stored keys per process.",
+              "type": "integer",
+              "minimum": 1,
+              "default": 10000
+            }
+          },
+          "if": {
+            "properties": {
+              "key": {
+                "const": "header"
+              }
+            },
+            "required": [
+              "key"
+            ]
+          },
+          "then": {
+            "properties": {
+              "header": {
+                "type": "string",
+                "minLength": 1,
+                "not": {
+                  "pattern": "[^!#$%&'*+.^_`|~0-9A-Za-z-]"
+                }
+              }
+            },
+            "required": [
+              "header"
+            ]
+          },
+          "else": {
+            "properties": {
+              "header": {
+                "const": ""
+              }
+            }
           }
         },
         "trusted_subnets": {

--- a/tests/configs/.rr-http-rate-limiter.yaml
+++ b/tests/configs/.rr-http-rate-limiter.yaml
@@ -1,0 +1,24 @@
+version: '3'
+
+rpc:
+  listen: tcp://127.0.0.1:6208
+
+server:
+  command: "php php_test_files/http/client.php echo pipes"
+  relay: pipes
+
+logs:
+  level: error
+
+http:
+  address: 127.0.0.1:18953
+  middleware: ["rate_limiter"]
+  rate_limiter:
+    key: global
+    rate: 1
+    interval: 1h
+    burst: 1
+  pool:
+    num_workers: 1
+    allocate_timeout: 10s
+    destroy_timeout: 5s

--- a/tests/e2e_http_test.go
+++ b/tests/e2e_http_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -25,6 +27,7 @@ import (
 	rrOtel "github.com/roadrunner-server/otel/v6"
 	"github.com/roadrunner-server/prometheus/v6"
 	proxyIP "github.com/roadrunner-server/proxy_ip_parser/v6"
+	"github.com/roadrunner-server/roadrunner/v2025/container"
 	rpcPlugin "github.com/roadrunner-server/rpc/v6"
 	"github.com/roadrunner-server/send/v6"
 	"github.com/roadrunner-server/server/v6"
@@ -144,6 +147,57 @@ func TestHTTPWithMiddleware(t *testing.T) {
 	select {
 	case err := <-errCh:
 		t.Fatal(err)
+	default:
+	}
+}
+
+func TestHTTPWithRateLimiter(t *testing.T) {
+	cont := endure.New(slog.LevelError, endure.GracefulShutdownTimeout(10*time.Second))
+	cfg := &config.Plugin{
+		Version: "2024.1.0",
+		Path:    "configs/.rr-http-rate-limiter.yaml",
+	}
+	require.NoError(t, cont.RegisterAll(append(container.Plugins(), cfg)...))
+	require.NoError(t, cont.Init())
+	t.Cleanup(func() { assert.NoError(t, cont.Stop()) })
+	results, err := cont.Serve()
+	require.NoError(t, err)
+
+	dialer := net.Dialer{Timeout: time.Second}
+	require.Eventually(t, func() bool {
+		conn, err := dialer.DialContext(t.Context(), "tcp", "127.0.0.1:18953")
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, 10*time.Second, 20*time.Millisecond)
+
+	client := newHTTPClient()
+	t.Cleanup(client.CloseIdleConnections)
+	for _, status := range []int{http.StatusCreated, http.StatusTooManyRequests} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://127.0.0.1:18953/?hello=world", nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.NoError(t, err)
+		require.Equal(t, status, resp.StatusCode)
+		if status == http.StatusCreated {
+			require.Equal(t, "WORLD", string(body))
+		} else {
+			retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, retryAfter, 1)
+			require.LessOrEqual(t, retryAfter, 3600)
+			require.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+		}
+	}
+
+	select {
+	case result := <-results:
+		require.Nil(t, result, "unexpected plugin error")
 	default:
 	}
 }


### PR DESCRIPTION
Bundle `github.com/roadrunner-server/rate-limiter/v6` at `v6.0.0-beta.1`.

- Register `rate_limiter` in the default HTTP plugin set.
- Add reference settings and the v3 configuration schema.
- Add an HTTP smoke test that uses the default bundle.

Documentation: roadrunner-server/docs#80.

closes: #934